### PR TITLE
Add estimated time remaining (ETA) during backup

### DIFF
--- a/ImageIntact/Models/PhaseBasedBackupEngine.swift
+++ b/ImageIntact/Models/PhaseBasedBackupEngine.swift
@@ -202,6 +202,10 @@ extension BackupManager {
         currentPhase = .copyingFiles
         currentFileIndex = 0
         
+        // Calculate and set total bytes for ETA
+        let manifestTotalSize = manifest.reduce(0) { $0 + $1.size }
+        totalBytesToCopy = manifestTotalSize * Int64(destinations.count)
+        
         // Track copied files for flush phase
         var copiedFiles: [(destination: URL, files: [URL])] = []
         for dest in destinations {
@@ -440,6 +444,9 @@ extension BackupManager {
         
         // Calculate total data size
         totalDataSize = manifest.reduce(0) { $0 + $1.size }
+        
+        // Set total bytes for ETA calculation (multiply by destination count)
+        totalBytesToCopy = totalDataSize * Int64(destinations.count)
         
         let totalTime = manifestBuildTime + copyTime + flushTime + verifyTime
         print("\n📊 Backup Summary:")

--- a/ImageIntact/Views/MultiDestinationProgressSection.swift
+++ b/ImageIntact/Views/MultiDestinationProgressSection.swift
@@ -122,6 +122,14 @@ struct SimpleBackupProgress: View {
                     
                     Spacer()
                     
+                    // ETA display
+                    let eta = backupManager.formattedETA()
+                    if !eta.isEmpty {
+                        Text(eta)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    
                     if backupManager.copySpeed > 0 {
                         Text("\(String(format: "%.1f", backupManager.copySpeed)) MB/s")
                             .font(.caption)

--- a/ImageIntact/Views/SimpleProgressSection.swift
+++ b/ImageIntact/Views/SimpleProgressSection.swift
@@ -37,6 +37,14 @@ struct SimpleProgressSection: View {
                                 
                                 Spacer()
                                 
+                                // ETA display
+                                let eta = backupManager.formattedETA()
+                                if !eta.isEmpty {
+                                    Text(eta)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                
                                 if backupManager.copySpeed > 0 {
                                     Text("\(String(format: "%.1f", backupManager.copySpeed)) MB/s")
                                         .font(.caption)


### PR DESCRIPTION
## Summary
Adds intelligent ETA calculation and display during backup operations to help photographers plan their workflow.

## Implementation
- **Smart calculation**: Uses weighted 30-second rolling average to smooth out speed fluctuations
- **User-friendly display**: Shows time in natural language ("About 5 minutes remaining")
- **Accurate predictions**: Accounts for total data size across all destinations
- **Stable updates**: Rounds to nearest 5 seconds to prevent jumpy estimates
- **Initial delay**: Shows "Calculating..." for first 5 seconds while gathering data

## Display Formats
- "Calculating..." (first 5 seconds)
- "Less than 1 minute remaining"
- "About 3 minutes remaining" 
- "About 45 minutes remaining"
- "About 1 hour 23 minutes remaining"

## Technical Details
- Weighted average favors recent speed samples for better responsiveness
- Updates ETA every second but only when speed changes significantly
- Properly resets tracking between backup sessions
- Works with both single and multiple destination backups

## Testing
✅ Build succeeds without errors
✅ ETA displays properly in both progress view modes
✅ Calculation logic handles edge cases (no data, zero speed, etc.)

## UI Changes
Added ETA display between file count and transfer speed in progress sections:
```
Files: 150/500     About 3 minutes remaining     4.5 MB/s
```

Fixes #9