### PR TITLE
fix: replace leaked NotificationCenter observers with .onReceive

### DIFF
--- a/ImageIntact/ContentView.swift
+++ b/ImageIntact/ContentView.swift
@@ -170,7 +170,9 @@ struct ContentView: View {
       selectSourceFolder()
     }
     .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("SelectDestination1")).receive(on: RunLoop.main)) { _ in
-      if !backupManager.destinationURLs.isEmpty { selectDestinationFolder(at: 0) }
+      Task { @MainActor in
+        if !backupManager.destinationURLs.isEmpty { selectDestinationFolder(at: 0) }
+      }
     }
     .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("AddDestination")).receive(on: RunLoop.main)) { _ in
       Task { @MainActor in backupManager.addDestination() }


### PR DESCRIPTION
## Summary

- Replace 12 manual `NotificationCenter.addObserver` calls in `setupMenuCommands()` with SwiftUI `.onReceive` modifiers
- Removes 115 lines of imperative observer code that leaked on every `onAppear`
- SwiftUI manages subscription lifecycle automatically — no manual cleanup needed

## Problem

`setupMenuCommands()` was called from `.onAppear` which fires on every window appearance. Observers were never removed (`removeObserver` appeared 0 times in the codebase). After N appearances, a single "RunBackup" notification would launch N concurrent backups.

## Fix

Replaced with Combine publishers + `.onReceive` modifiers on the view body. This is the idiomatic SwiftUI pattern — subscriptions are tied to the view lifecycle automatically.

## Test plan

- [x] 302 tests pass (0 failures)
- [ ] Manual: Launch app, use menu commands — should work
- [ ] Manual: Close and reopen window — menu commands work exactly once per click
- [ ] Manual: Verify no duplicate "Starting backup" in logs

Closes finding #13 in #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)