### PR TITLE
fix: concurrency fixes (GH #91 findings #10, #11, #12, #18)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -413,7 +413,10 @@ class BackupManager {
                 if index < self.destinationKeys.count {
                     UserDefaults.standard.removeObject(forKey: self.destinationKeys[index])
                 }
-                self.destinationItems[index] = DestinationItem(url: nil)
+                // Mutate in place to preserve UUID — replacing the struct
+                // orphans the driveInfo entry keyed by the old UUID.
+                // See: GH issue #91, finding #18.
+                self.destinationItems[index].url = nil
             }
             return
         }

--- a/ImageIntact/Models/QueueSystem/BackupCoordinator.swift
+++ b/ImageIntact/Models/QueueSystem/BackupCoordinator.swift
@@ -196,28 +196,20 @@ class BackupCoordinator: ObservableObject {
         shouldCancel = true
         statusMessage = "Backup cancelled"
 
-        // Immediately clear all statuses to stop UI updates
-        for (name, _) in destinationStatuses {
-            destinationStatuses[name] = DestinationStatus(
-                name: name,
-                completed: 0,
-                total: 0,
-                speed: "Cancelled",
-                eta: nil,
-                isComplete: true, // Mark as complete to stop monitoring
-                hasFailed: false,
-                isVerifying: false,
-                verifiedCount: 0
-            )
-        }
+        // Don't mutate destinationStatuses here — the monitoring loop checks
+        // shouldCancel and will exit cleanly. Mutating statuses to "complete"
+        // before the loop exits causes UI flicker between "complete" and
+        // "cancelled". See: GH issue #91, finding #10.
 
+        ApplicationLogger.shared.debug("CANCELLING: Stopping all destination queues", category: .backup)
+
+        // Stop all queues. Use a Task because cancelBackup() is called
+        // synchronously from the UI. Don't clear data arrays — the UI may
+        // still need to display what succeeded/failed before cancellation.
+        // Data is cleaned up when startBackup() is called next.
         Task { [weak self] in
             guard let self = self else { return }
 
-            // Log cancellation
-            ApplicationLogger.shared.debug("CANCELLING: Stopping all destination queues immediately", category: .backup)
-
-            // Stop all queues in parallel for faster cancellation
             await withTaskGroup(of: Void.self) { group in
                 for queue in self.destinationQueues {
                     group.addTask {
@@ -227,15 +219,6 @@ class BackupCoordinator: ObservableObject {
             }
 
             ApplicationLogger.shared.debug("All queues stopped", category: .backup)
-
-            // Clear queues to release memory
-            self.destinationQueues.removeAll()
-            // Clear manifest to free memory
-            self.manifest.removeAll(keepingCapacity: false)
-            // Clear all tracking data
-            self.destinationStatuses.removeAll(keepingCapacity: false)
-            self.collectedFailures.removeAll(keepingCapacity: false)
-            // Only set isRunning to false after cleanup
             self.isRunning = false
         }
     }

--- a/ImageIntact/Models/QueueSystem/DestinationQueue.swift
+++ b/ImageIntact/Models/QueueSystem/DestinationQueue.swift
@@ -212,9 +212,22 @@ actor DestinationQueue {
                 // inflating failedFiles.count which breaks isComplete().
                 // See: GH issue #91, finding #2.
                 if task.attemptCount < 3 {
+                    // Exponential backoff: 0.5s, 1s, 2s
+                    // See: GH issue #91, finding #11.
+                    let delayNs = UInt64(500_000_000) << UInt64(task.attemptCount)
+                    do {
+                        try await Task.sleep(nanoseconds: delayNs)
+                    } catch {
+                        // Task was cancelled during the delay — don't retry
+                        break
+                    }
+
+                    // Don't retry if backup was cancelled during the delay
+                    guard !shouldCancel else { break }
+
                     var retryTask = task
                     retryTask.attemptCount += 1
-                    retryTask.lastError = error
+                    retryTask.lastError = String(describing: error)
                     await queue.enqueue(retryTask)
                 } else {
                     failedFiles.append((file: task.relativePath, error: error.localizedDescription))

--- a/ImageIntact/Models/QueueSystem/FileTask.swift
+++ b/ImageIntact/Models/QueueSystem/FileTask.swift
@@ -22,7 +22,7 @@ struct FileTask: Identifiable {
   let priority: TaskPriority
   let addedTime: Date = Date()
   var attemptCount: Int = 0
-  var lastError: Error?
+  var lastError: String?  // Sendable-safe error description (Error is not Sendable)
 
   // For priority queue ordering
   var score: Double {

--- a/ImageIntactTests/QueueSystem/BackupCoordinatorTests.swift
+++ b/ImageIntactTests/QueueSystem/BackupCoordinatorTests.swift
@@ -181,8 +181,8 @@ final class BackupCoordinatorTests: XCTestCase {
             )
         }
         
-        // Wait for some progress
-        await fulfillment(of: [expectation], timeout: 5.0)
+        // Wait for some progress (retry backoff delays mean this can take longer)
+        await fulfillment(of: [expectation], timeout: 15.0)
         
         // Then
         XCTAssertFalse(progressUpdates.isEmpty, "Should have progress updates")

--- a/ImageIntactTests/QueueSystem/RetryCountTests.swift
+++ b/ImageIntactTests/QueueSystem/RetryCountTests.swift
@@ -136,7 +136,7 @@ final class RetryCountTests: XCTestCase {
         // When
         await queue.addTasks(tasks)
         await queue.start()
-        await waitForCompletion(queue: queue, timeout: 10.0)
+        await waitForCompletion(queue: queue, timeout: 30.0)
 
         // Then
         let failedFiles = await queue.failedFiles
@@ -171,7 +171,8 @@ final class RetryCountTests: XCTestCase {
             fileOperations: alwaysFailMock
         )
 
-        let totalFileCount = 10
+        // Use small count — each file has retry backoff delays (0.5s + 1s + 2s = 3.5s per file)
+        let totalFileCount = 3
         var tasks: [FileTask] = []
         for i in 0..<totalFileCount {
             let sourceURL = URL(fileURLWithPath: "/source/file\(i).jpg")
@@ -185,7 +186,7 @@ final class RetryCountTests: XCTestCase {
 
         await queue.addTasks(tasks)
         await queue.start()
-        await waitForCompletion(queue: queue, timeout: 15.0)
+        await waitForCompletion(queue: queue, timeout: 30.0)
 
         let failedFiles = await queue.failedFiles
         let verifiedFiles = await queue.verifiedFiles
@@ -195,6 +196,8 @@ final class RetryCountTests: XCTestCase {
             "BUG #2: verified (\(verifiedFiles)) + failed (\(failedFiles.count)) = " +
             "\(verifiedFiles + failedFiles.count), which exceeds total (\(totalFileCount)). " +
             "Retry inflation is causing overcounting.")
+        XCTAssertEqual(failedFiles.count, totalFileCount,
+                       "All \(totalFileCount) files should have exactly 1 failure entry each")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

Four concurrency/correctness fixes from the code review (GH #91):

- **#12** FileTask.lastError: `Error?` → `String?` for Sendable safety across actor boundaries
- **#11** Retry backoff: exponential delay (0.5s, 1s, 2s) + cancellation check before retry
- **#10** Cancel race: removed intermediate "complete" status mutation that caused UI flicker
- **#18** DestinationItem UUID: mutate url in place instead of replacing struct (orphaned driveInfo)

## Test plan

- [x] 321 tests pass (0 failures)
- [x] Test timeouts adjusted for retry backoff delays
- [ ] Manual: Cancel mid-backup — UI should show "Backup cancelled" without flickering to "complete"

Addresses findings #10, #11, #12, #18 in #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)