### PR TITLE
refactor: move BackupCoordinator polling off main thread (GH #91 #9)

### DIFF
--- a/ImageIntact/Models/QueueSystem/BackupCoordinator.swift
+++ b/ImageIntact/Models/QueueSystem/BackupCoordinator.swift
@@ -136,37 +136,39 @@ class BackupCoordinator: ObservableObject {
         // Start all queues
         statusMessage = "Starting parallel backup to \(destinations.count) destinations..."
 
-        await withTaskGroup(of: Void.self) { group in
-            for queue in destinationQueues {
-                group.addTask { [weak self, weak queue] in
-                    guard let queue = queue else { return }
-                    await queue.start()
+        // Run queue management and monitoring off the main thread.
+        // Property mutations inside monitorProgress() use await MainActor.run.
+        // See: GH issue #91, finding #9.
+        await Task.detached { [weak self] in
+            guard let self = self else { return }
+            await withTaskGroup(of: Void.self) { group in
+                for queue in await self.destinationQueues {
+                    group.addTask { [weak self, weak queue] in
+                        guard let queue = queue else { return }
+                        await queue.start()
 
-                    // Wait for completion
-                    while await !queue.isComplete() {
-                        // Check cancellation from main actor
-                        let cancelled = await MainActor.run { [weak self] in
-                            self?.shouldCancel ?? true
+                        // Wait for completion
+                        while await !queue.isComplete() {
+                            if await self?.shouldCancel ?? true {
+                                await queue.stop()
+                                break
+                            }
+                            try? await Task.sleep(nanoseconds: 100_000_000) // Check every 0.1s
                         }
-                        if cancelled {
-                            await queue.stop()
-                            break
-                        }
-                        try? await Task.sleep(nanoseconds: 100_000_000) // Check every 0.1s
                     }
                 }
+
+                // Start monitoring task with weak self
+                group.addTask { [weak self] in
+                    await self?.monitorProgress()
+                }
+
+                // Wait for all to complete
+                await group.waitForAll()
             }
+        }.value
 
-            // Start monitoring task with weak self
-            group.addTask { [weak self] in
-                await self?.monitorProgress()
-            }
-
-            // Wait for all to complete
-            await group.waitForAll()
-        }
-
-        // Final status
+        // Back on MainActor after detached task completes
         await finalizeBackup()
 
         // Clean up all queues to prevent retain cycles


### PR DESCRIPTION
## Summary

The `withTaskGroup` that manages destination queues and `monitorProgress()` polling was running entirely on the main thread (inherited from `@MainActor` class). With 4 destinations, this caused dozens of main-actor hops per second alongside UI rendering.

**Fix:** Wrap the `withTaskGroup` in `Task.detached { }.value` so queue management and monitoring run on background cooperative threads. Property mutations stay on MainActor via existing `await MainActor.run` blocks.

**What changed:**
- `startBackup()`: heavy work wrapped in `Task.detached`
- `shouldCancel` check simplified (NSLock-protected, no MainActor.run needed)
- After detached task completes, execution returns to MainActor for `finalizeBackup()`

**What didn't change:**
- Class-level `@MainActor` (protects `@Published` properties)
- `ObservableObject` conformance
- `await MainActor.run` in `monitorProgress()` (still needed for property mutation)
- `cancelBackup()` (called from UI, stays on MainActor)

## Test plan

- [x] 321 tests pass (0 failures)
- [ ] Manual: run a large multi-destination backup — UI should remain responsive

Closes finding #9 in #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)