### PR TITLE
refactor: extract formatting helpers from BackupManager (#103)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -948,15 +948,4 @@ extension BackupManager {
         }
     }
 
-    // MARK: - Formatting Helpers
-
-    func formatTime(_ seconds: TimeInterval) -> String {
-        TimeFormatter.formatDuration(seconds)
-    }
-
-    func formatDataSize(_ bytes: Int64) -> String {
-        let formatter = ByteCountFormatter()
-        formatter.countStyle = .binary
-        return formatter.string(fromByteCount: bytes)
-    }
 }

--- a/ImageIntact/Models/BackupManagerQueueIntegration.swift
+++ b/ImageIntact/Models/BackupManagerQueueIntegration.swift
@@ -713,7 +713,7 @@ extension BackupManager {
         // Calculate estimated time
         let estimatedSpeed = 50.0 // MB/s - conservative estimate
         let seconds = Double(totalBytes) / (estimatedSpeed * 1_000_000)
-        let timeString = formatTime(seconds)
+        let timeString = TimeFormatter.formatDuration(seconds)
 
         largeBackupInfo = LargeBackupInfo(
             fileCount: manifest.count,

--- a/ImageIntact/Utilities/DataSizeFormatter.swift
+++ b/ImageIntact/Utilities/DataSizeFormatter.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Shared data size formatting utility
+enum DataSizeFormatter {
+    /// Format byte count into human-readable size (e.g., "1 KB", "100 MB")
+    ///
+    /// Creates a new ByteCountFormatter per call to avoid Swift 6 strict concurrency
+    /// issues with caching a non-Sendable NSObject subclass in a static let.
+    static func format(_ bytes: Int64) -> String {
+        let f = ByteCountFormatter()
+        f.countStyle = .binary
+        f.allowsNonnumericFormatting = false
+        return f.string(fromByteCount: bytes)
+    }
+}

--- a/ImageIntactTests/DataSizeFormatterTests.swift
+++ b/ImageIntactTests/DataSizeFormatterTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import ImageIntact
+
+final class DataSizeFormatterTests: XCTestCase {
+
+    /// Normalize non-breaking and narrow no-break spaces to regular spaces
+    private func normalized(_ s: String) -> String {
+        s.replacingOccurrences(of: "[\\u{00A0}\\u{202F}]", with: " ", options: .regularExpression)
+    }
+
+    func testExactBoundaries() {
+        XCTAssertEqual(normalized(DataSizeFormatter.format(1024)), "1 KB")
+        XCTAssertEqual(normalized(DataSizeFormatter.format(1024 * 1024)), "1 MB")
+        XCTAssertEqual(normalized(DataSizeFormatter.format(1024 * 1024 * 1024)), "1 GB")
+    }
+
+    func testFractionalSizes() {
+        XCTAssertEqual(normalized(DataSizeFormatter.format(1024 * 1024 + 512 * 1024)), "1.5 MB")
+    }
+
+    func testZeroBytes() {
+        // allowsNonnumericFormatting = false → numeric "0" not "Zero"
+        let result = normalized(DataSizeFormatter.format(0))
+        XCTAssertTrue(result.contains("0"), "Expected numeric zero in: \(result)")
+    }
+}

--- a/ImageIntactTests/DataSizeFormatterTests.swift
+++ b/ImageIntactTests/DataSizeFormatterTests.swift
@@ -3,9 +3,10 @@ import XCTest
 
 final class DataSizeFormatterTests: XCTestCase {
 
-    /// Normalize non-breaking and narrow no-break spaces to regular spaces
+    /// Normalize non-breaking spaces and locale-specific decimal separators for assertions
     private func normalized(_ s: String) -> String {
         s.replacingOccurrences(of: "[\\u{00A0}\\u{202F}]", with: " ", options: .regularExpression)
+         .replacingOccurrences(of: ",", with: ".")
     }
 
     func testExactBoundaries() {

--- a/ImageIntactTests/TimeFormatterTests.swift
+++ b/ImageIntactTests/TimeFormatterTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import ImageIntact
+
+final class TimeFormatterTests: XCTestCase {
+    func testFormatDuration() {
+        XCTAssertEqual(TimeFormatter.formatDuration(45.5), "45s")
+        XCTAssertEqual(TimeFormatter.formatDuration(65), "1m 5s")
+        XCTAssertEqual(TimeFormatter.formatDuration(125.5), "2m 5s")
+        // Intentionally drops seconds for hour-scale durations
+        XCTAssertEqual(TimeFormatter.formatDuration(3665), "1h 1m")
+    }
+}

--- a/ImageIntactTests/UIStateManagementTests.swift
+++ b/ImageIntactTests/UIStateManagementTests.swift
@@ -171,31 +171,6 @@ class UIStateManagementTests: XCTestCase {
         XCTAssertEqual(session2.count, 36) // UUID format
     }
 
-    // MARK: - Formatting Tests
-
-    func testTimeFormatting() {
-        XCTAssertEqual(backupManager.formatTime(45.5), "45s")
-        XCTAssertEqual(backupManager.formatTime(65), "1m 5s")
-        XCTAssertEqual(backupManager.formatTime(125.5), "2m 5s")
-        XCTAssertEqual(backupManager.formatTime(3665), "1h 1m")
-    }
-
-    func testDataSizeFormatting() {
-        // Test various sizes
-        let formatter = backupManager.formatDataSize
-
-        // Small sizes
-        XCTAssertNotNil(formatter(1024)) // 1 KB
-        XCTAssertNotNil(formatter(1024 * 1024)) // 1 MB
-        XCTAssertNotNil(formatter(1024 * 1024 * 1024)) // 1 GB
-
-        // The actual format depends on ByteCountFormatter
-        // We just verify it returns something
-        XCTAssertFalse(formatter(0).isEmpty)
-        XCTAssertFalse(formatter(1024).isEmpty)
-        XCTAssertFalse(formatter(1024 * 1024 * 100).isEmpty)
-    }
-
     // MARK: - Log Entry Tests
 
     func testLogEntryCreation() {


### PR DESCRIPTION
## Summary
- Extract `formatTime` and `formatDataSize` from BackupManager into dedicated utilities (`TimeFormatter`, `DataSizeFormatter`)
- New `DataSizeFormatter` enum in its own file (SRP) — no cached formatter to avoid Swift 6 strict concurrency issues with non-Sendable `ByteCountFormatter`
- Tests moved to dedicated `DataSizeFormatterTests` and `TimeFormatterTests` with exact assertions and non-breaking space normalization

## Test plan
- [ ] `DataSizeFormatterTests` passes (exact boundaries, fractional sizes, zero bytes)
- [ ] `TimeFormatterTests` passes (duration formatting across second/minute/hour scales)
- [ ] No remaining references to `backupManager.formatTime` or `backupManager.formatDataSize`
- [ ] Build succeeds with no warnings

Part of #103 (BackupManager decomposition). BackupManager: 962 → 951 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)