### PR TITLE
fix: recognize Hasselblad .3fr RAW and .phos sidecars

### DIFF
--- a/ImageIntact/Models/FileTypeFilter.swift
+++ b/ImageIntact/Models/FileTypeFilter.swift
@@ -66,23 +66,34 @@ public struct FileTypeFilter: Codable, Equatable {
   /// No filtering - include all files
   public static let allFiles = FileTypeFilter()
 
-  /// RAW files only
-  public static let rawOnly = FileTypeFilter(extensions: [
-    "nef", "cr2", "cr3", "arw", "orf", "rw2", "dng", "raf", "raw", "rwl", "srw", "x3f",
-  ])
+  /// RAW files only — derived from `ImageFileType` so new RAW formats added to the enum
+  /// are automatically picked up by this preset (single source of truth).
+  public static let rawOnly: FileTypeFilter = {
+    var extensions = Set<String>()
+    for type in ImageFileType.allCases where type.isRaw {
+      extensions.formUnion(type.extensions)
+    }
+    return FileTypeFilter(extensions: extensions)
+  }()
 
-  /// All photo types (RAW + processed)
-  public static let photosOnly = FileTypeFilter(extensions: [
-    // RAW formats
-    "nef", "cr2", "cr3", "arw", "orf", "rw2", "dng", "raf", "raw", "rwl", "srw", "x3f",
-    // Processed formats
-    "jpg", "jpeg", "heic", "heif", "png", "tiff", "tif", "bmp", "webp",
-  ])
+  /// All photo types (RAW + processed) — derived from `ImageFileType`.
+  /// Includes anything that is neither a video nor a sidecar/catalog file.
+  public static let photosOnly: FileTypeFilter = {
+    var extensions = Set<String>()
+    for type in ImageFileType.allCases where !type.isVideo && !type.isSidecar {
+      extensions.formUnion(type.extensions)
+    }
+    return FileTypeFilter(extensions: extensions)
+  }()
 
-  /// Video files only
-  public static let videosOnly = FileTypeFilter(extensions: [
-    "mov", "mp4", "avi", "mkv", "m4v", "mpg", "mpeg", "wmv", "flv", "webm", "mts", "m2ts",
-  ])
+  /// Video files only — derived from `ImageFileType`.
+  public static let videosOnly: FileTypeFilter = {
+    var extensions = Set<String>()
+    for type in ImageFileType.allCases where type.isVideo {
+      extensions.formUnion(type.extensions)
+    }
+    return FileTypeFilter(extensions: extensions)
+  }()
 
   // MARK: - Helper Properties
 

--- a/ImageIntact/Models/ImageFileType.swift
+++ b/ImageIntact/Models/ImageFileType.swift
@@ -40,6 +40,7 @@ enum ImageFileType: String, CaseIterable {
     case cos = "COS" // Capture One settings
     case pp3 = "PP3" // RawTherapee
     case arp = "ARP" // Adobe Camera Raw
+    case phos = "PHOS" // Hasselblad Phocus sidecar
     case lrcat = "LR Catalog" // Lightroom catalog
     case lrdata = "LR Data" // Lightroom data
     case cocatalog = "C1 Catalog" // Capture One catalog
@@ -83,7 +84,8 @@ enum ImageFileType: String, CaseIterable {
     case rwl = "RWL"
 
     // Hasselblad
-    case fff = "FFF"
+    case threefr = "3FR" // Hasselblad newer RAW
+    case fff = "FFF" // Hasselblad older RAW
     case x3f = "X3F" // Also Sigma
 
     // Phase One
@@ -141,6 +143,8 @@ enum ImageFileType: String, CaseIterable {
             return ["pp3"]
         case .arp:
             return ["arp"]
+        case .phos:
+            return ["phos"]
         case .lrcat:
             return ["lrcat", "lrcat-data"]
         case .lrdata:
@@ -182,6 +186,8 @@ enum ImageFileType: String, CaseIterable {
             return ["pef"]
         case .rwl:
             return ["rwl"]
+        case .threefr:
+            return ["3fr"]
         case .fff:
             return ["fff"]
         case .x3f:
@@ -223,7 +229,7 @@ enum ImageFileType: String, CaseIterable {
         switch self {
         case .jpeg, .tiff, .png, .heic, .heif, .webp, .bmp, .gif,
              .mov, .mp4, .avi, .m4v, .mpg, .mts, .m2ts, .wmv, .flv, .webm, .mkv, .mpeg,
-             .xmp, .dop, .cos, .pp3, .arp, .aae, .thm, .lrcat, .lrdata, .cocatalog, .cocatalogdb:
+             .xmp, .dop, .cos, .pp3, .arp, .phos, .aae, .thm, .lrcat, .lrdata, .cocatalog, .cocatalogdb:
             return false
         default:
             return true
@@ -241,7 +247,7 @@ enum ImageFileType: String, CaseIterable {
 
     var isSidecar: Bool {
         switch self {
-        case .xmp, .dop, .cos, .pp3, .arp, .aae, .thm, .lrcat, .lrdata, .cocatalog, .cocatalogdb:
+        case .xmp, .dop, .cos, .pp3, .arp, .phos, .aae, .thm, .lrcat, .lrdata, .cocatalog, .cocatalogdb:
             return true
         default:
             return false
@@ -270,7 +276,7 @@ enum ImageFileType: String, CaseIterable {
         // RAW files are typically large
         case .dng, .cr2, .cr3, .nef, .arw, .orf, .rw2, .raf, .pef, .srw, .erf, .crw, .raw:
             return 25_000_000 // ~25 MB average for modern RAW files
-        case .nrw, .rwl, .iiq, .mos, .dcr, .mef, .mrw, .kdc, .srf, .sr2, .ptx, .fff, .x3f:
+        case .nrw, .rwl, .iiq, .mos, .dcr, .mef, .mrw, .kdc, .srf, .sr2, .ptx, .fff, .threefr, .x3f:
             return 20_000_000 // ~20 MB for these RAW formats
         // Standard images
         case .jpeg:
@@ -297,7 +303,7 @@ enum ImageFileType: String, CaseIterable {
         case .m4v, .wmv, .flv, .webm, .mkv:
             return 20_000_000 // ~20 MB
         // Sidecar files are small
-        case .xmp, .aae, .dop, .cos, .pp3, .arp:
+        case .xmp, .aae, .dop, .cos, .pp3, .arp, .phos:
             return 50000 // ~50 KB
         case .thm:
             return 100_000 // ~100 KB (thumbnail)

--- a/ImageIntact/Models/UTIFileTypeDetector.swift
+++ b/ImageIntact/Models/UTIFileTypeDetector.swift
@@ -140,7 +140,8 @@ class UTIFileTypeDetector {
             "com.olympus.orf-raw", // Olympus ORF
             "com.panasonic.rw2-raw", // Panasonic RW2
             "com.pentax.pef-raw", // Pentax PEF
-            "com.hasselblad.fff-raw", // Hasselblad FFF
+            "com.hasselblad.fff-raw", // Hasselblad FFF (older)
+            "com.hasselblad.3fr-raw", // Hasselblad 3FR (newer)
             "com.phaseone.iiq-raw", // Phase One IIQ
             "com.leica.rwl-raw", // Leica RWL
             "com.samsung.srw-raw", // Samsung SRW

--- a/ImageIntact/Views/HelpWindowView.swift
+++ b/ImageIntact/Views/HelpWindowView.swift
@@ -584,6 +584,7 @@ struct FileTypesContent: View {
           Text("**Nikon**: NEF, NRW")
           Text("**Sony**: ARW, SRF, SR2")
           Text("**Fujifilm**: RAF")
+          Text("**Hasselblad**: 3FR, FFF")
           Text("**Others**: DNG, ORF, RW2, PEF, IIQ, and 20+ more")
         }
         .font(.callout)
@@ -602,6 +603,7 @@ struct FileTypesContent: View {
           Text("**Adobe**: XMP sidecars, DNG")
           Text("**Lightroom**: Catalogs (.lrcat), Preview data (.lrdata)")
           Text("**Capture One**: Catalogs (.cocatalog), Sessions (.cosessiondb), Settings (.cos)")
+          Text("**Hasselblad Phocus**: Sidecars (.phos)")
           Text("**Apple**: AAE sidecars")
           Text("**Others**: DxO (.dop), RawTherapee (.pp3)")
         }

--- a/ImageIntactTests/ImageFileTypeTests.swift
+++ b/ImageIntactTests/ImageFileTypeTests.swift
@@ -5,22 +5,62 @@ final class ImageFileTypeTests: XCTestCase {
     
     // MARK: - File Type Detection Tests
     
-    func testRAWFileDetection() {
-        // Test common RAW formats
-        let rawExtensions = ["nef", "cr2", "arw", "dng", "orf", "rw2", "pef", "srw", "x3f", "raf"]
-        
+    func testRAWFileDetection() throws {
+        // Test common RAW formats, including both Hasselblad formats (3fr newer, fff older)
+        let rawExtensions = [
+            "nef", "cr2", "arw", "dng", "orf", "rw2", "pef", "srw", "x3f", "raf",
+            "3fr", "fff", "iiq", "mef", "mos",
+        ]
+
         for ext in rawExtensions {
             let url = URL(fileURLWithPath: "/test/photo.\(ext)")
             XCTAssertTrue(ImageFileType.isImageFile(url), "\(ext) should be recognized as image file")
-            
-            if let fileType = ImageFileType.from(fileExtension: ext) {
-                XCTAssertTrue(fileType.isRaw, "\(ext) should be recognized as RAW")
-                XCTAssertFalse(fileType.isVideo, "\(ext) should not be video")
-                XCTAssertFalse(fileType.isSidecar, "\(ext) should not be sidecar")
-            } else {
-                XCTFail("Failed to detect file type for \(ext)")
-            }
+
+            // Use XCTUnwrap so a missing mapping fails the test instead of silently passing
+            let fileType = try XCTUnwrap(
+                ImageFileType.from(fileExtension: ext),
+                "\(ext) should map to an ImageFileType case"
+            )
+            XCTAssertTrue(fileType.isRaw, "\(ext) should be recognized as RAW")
+            XCTAssertFalse(fileType.isVideo, "\(ext) should not be video")
+            XCTAssertFalse(fileType.isSidecar, "\(ext) should not be sidecar")
         }
+    }
+
+    func testHasselbladFormats() {
+        // Hasselblad shoots .3fr (newer) and .fff (older) RAW, with .phos sidecars from Phocus
+        XCTAssertEqual(ImageFileType.from(fileExtension: "3fr"), .threefr)
+        XCTAssertEqual(ImageFileType.from(fileExtension: "3FR"), .threefr, "should be case-insensitive")
+        XCTAssertTrue(ImageFileType.threefr.isRaw)
+        XCTAssertFalse(ImageFileType.threefr.isSidecar)
+
+        XCTAssertEqual(ImageFileType.from(fileExtension: "fff"), .fff)
+        XCTAssertTrue(ImageFileType.fff.isRaw)
+
+        // Phocus sidecar
+        XCTAssertEqual(ImageFileType.from(fileExtension: "phos"), .phos)
+        XCTAssertEqual(ImageFileType.from(fileExtension: "PHOS"), .phos, "should be case-insensitive")
+        XCTAssertTrue(ImageFileType.phos.isSidecar)
+        XCTAssertFalse(ImageFileType.phos.isRaw)
+        XCTAssertFalse(ImageFileType.phos.isVideo)
+
+        // Hasselblad RAW should pass through both filter presets
+        XCTAssertTrue(FileTypeFilter.rawOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/img.3fr")))
+        XCTAssertTrue(FileTypeFilter.rawOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/img.fff")))
+        XCTAssertTrue(FileTypeFilter.photosOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/img.3fr")))
+        XCTAssertTrue(FileTypeFilter.photosOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/img.fff")))
+
+        // Phocus sidecars are NOT in the RAW or Photos presets — they're sidecars.
+        // Note: this means picking "RAW Only" silently drops the sidecar (same as
+        // existing behavior for .xmp). The fix for that is a separate concern from
+        // recognition; tracked outside this change.
+        XCTAssertFalse(FileTypeFilter.rawOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/img.phos")))
+        XCTAssertFalse(FileTypeFilter.photosOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/img.phos")))
+        XCTAssertFalse(FileTypeFilter.videosOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/img.phos")))
+
+        // Filter must be case-insensitive at the URL level — cameras often produce uppercase extensions
+        XCTAssertTrue(FileTypeFilter.rawOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/IMG.3FR")))
+        XCTAssertTrue(FileTypeFilter.rawOnly.shouldInclude(fileURL: URL(fileURLWithPath: "/IMG.FFF")))
     }
     
     func testStandardImageDetection() {
@@ -54,7 +94,7 @@ final class ImageFileTypeTests: XCTestCase {
     }
     
     func testSidecarFileDetection() {
-        let sidecarFormats = ["xmp", "aae", "thm", "dop", "pp3"]
+        let sidecarFormats = ["xmp", "aae", "thm", "dop", "pp3", "phos"]
         
         for ext in sidecarFormats {
             let url = URL(fileURLWithPath: "/test/metadata.\(ext)")


### PR DESCRIPTION
## Summary

- Add `.phos` (Hasselblad Phocus sidecar) and `.3fr` (Hasselblad newer RAW) to `ImageFileType` so backups no longer silently skip them.
- Refactor `FileTypeFilter.{rawOnly, photosOnly, videosOnly}` to derive from `ImageFileType.allCases` — fixes a hidden gap where many RAW formats already in the enum (`.fff`, `.iiq`, `.mef`, `.mos`, `.nrw`, `.srf`, `.sr2`, `.pef`, `.ptx`, `.crw`, `.dcr`, `.kdc`, `.erf`, `.mrw`) were silently dropped when users picked the "RAW Only" preset. Now the filter lists are a derived single source of truth.
- Register `com.hasselblad.3fr-raw` UTI alongside the existing `com.hasselblad.fff-raw`.
- Mention Hasselblad and Phocus in the in-app help file-types page.

## Context

A user reported that Hasselblad `.phos` sidecars weren't recognized. Tracing the bug revealed a broader pattern: `FileTypeFilter` hardcoded its preset extension lists, and the lists had drifted away from the `ImageFileType` enum. Fixing this with a derivation also fixes the same latent bug for Phase One / Mamiya / Leaf / Kodak / Epson / Minolta RAW formats.

## Tests

- Extended `testRAWFileDetection` with `3fr, fff, iiq, mef, mos`. Switched from `if let` to `XCTUnwrap` so missing mappings fail loud instead of silently passing.
- Extended `testSidecarFileDetection` with `phos`.
- Added `testHasselbladFormats` covering: case-insensitive enum lookup, classification flags (`isRaw` / `isSidecar`), positive filter inclusion for `.3fr`/`.fff`, negative filter assertions for `.phos`, and case-insensitive URL extension matching.

All 31 tests in `ImageFileTypeTests` + `FileTypeFilterTests` pass locally.

## Review

Ran the changes through a 3-reviewer Gemini panel (Security / Architecture / Correctness) twice:
- **Round 1** flagged DRY violation (High) and silent test failure risk (Medium). Both addressed in this PR before review round 2.
- **Round 2** verdict: Ready to Merge. No Blocker / High / Medium findings.

## Deliberately out of scope

- **Sidecar pairing under filter presets.** `ManifestBuilder.swift:232` strictly enforces `filter.shouldInclude(fileURL:)` per file with no parent-pairing, so picking "RAW Only" silently drops `.phos` (and `.xmp`, `.aae`, etc. — this is pre-existing for all sidecars). Fixing it requires a stateful two-pass scan in the manifest builder. Tracked as a separate product decision.
- **`isRaw` "negative filter" fragility.** The `isRaw` property defaults to `true`, so a future developer adding a new non-RAW format without updating the exclusion list would silently classify it as RAW. Should be flipped to an explicit positive list during the future "God Enum" refactor.

## Test plan

- [ ] Manual: point ImageIntact at a folder containing `.3fr` + `.phos` files, run backup, verify both copied
- [ ] Manual: with "RAW Only" filter selected, verify `.3fr`/`.fff` files are backed up (they are silently skipped today)
- [ ] Manual: verify the help window shows the Hasselblad / Phocus entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)