### PR TITLE
perf: consolidate IOKit queries and cache drive analysis

### DIFF
--- a/ImageIntact/Models/DriveAnalyzer.swift
+++ b/ImageIntact/Models/DriveAnalyzer.swift
@@ -5,7 +5,7 @@ import IOKit.storage
 import IOKit.usb
 
 class DriveAnalyzer {
-    enum ConnectionType {
+    enum ConnectionType: Equatable {
         case usb2
         case usb30
         case usb31Gen1
@@ -38,37 +38,30 @@ class DriveAnalyzer {
             }
         }
 
-        // Real-world speeds (conservative estimates for actual file copying)
-        // These are much lower than theoretical max due to:
-        // - File system overhead
-        // - Small file penalties
-        // - OS caching and buffering
-        // - Multiple simultaneous destinations
         var estimatedWriteSpeedMBps: Double {
             switch self {
-            case .usb2: return 20 // ~20 MB/s real world
-            case .usb30: return 100 // ~100 MB/s (typical USB 3.0 HDD)
-            case .usb31Gen1: return 120 // ~120 MB/s
-            case .usb31Gen2: return 200 // ~200 MB/s
-            case .usb32Gen2x2: return 300 // ~300 MB/s
-            case .thunderbolt3: return 400 // ~400 MB/s (typical external SSD)
-            case .thunderbolt4: return 500 // ~500 MB/s
-            case .thunderbolt5: return 600 // ~600 MB/s
-            case .internalDrive: return 300 // ~300 MB/s (average internal SSD)
-            case .network: return 50 // ~50 MB/s (typical network)
-            case .sdCard: return 80 // ~80 MB/s (UHS-I SD card)
-            case .cfCard: return 150 // ~150 MB/s (CFexpress Type A)
-            case .unknown: return 80 // Conservative estimate
+            case .usb2: return 20
+            case .usb30: return 100
+            case .usb31Gen1: return 120
+            case .usb31Gen2: return 200
+            case .usb32Gen2x2: return 300
+            case .thunderbolt3: return 400
+            case .thunderbolt4: return 500
+            case .thunderbolt5: return 600
+            case .internalDrive: return 300
+            case .network: return 50
+            case .sdCard: return 80
+            case .cfCard: return 150
+            case .unknown: return 80
             }
         }
 
         var estimatedReadSpeedMBps: Double {
-            // Reads are typically slightly faster
             return estimatedWriteSpeedMBps * 1.1
         }
     }
 
-    enum DriveType {
+    enum DriveType: Equatable {
         case portableSSD
         case externalHDD
         case cameraCard
@@ -104,7 +97,7 @@ class DriveAnalyzer {
         var autoBackupRecommended: Bool {
             switch self {
             case .cameraCard, .cardReader, .inCamera:
-                return false // Don't auto-backup to camera cards
+                return false
             default:
                 return true
             }
@@ -117,46 +110,30 @@ class DriveAnalyzer {
         let isSSD: Bool
         let deviceName: String
         let protocolDetails: String
-        let estimatedWriteSpeed: Double // MB/s
-        let estimatedReadSpeed: Double // MB/s
-        let checksumSpeed: Double = 100 // SHA-256 speed (conservative for mixed file sizes)
+        let estimatedWriteSpeed: Double
+        let estimatedReadSpeed: Double
+        let checksumSpeed: Double = 100
 
-        // Drive identification
         let volumeUUID: String?
         let hardwareSerial: String?
         let deviceModel: String?
 
-        // Drive capacity
         let totalCapacity: Int64
         let freeSpace: Int64
 
-        // Smart detection
         let driveType: DriveType
 
         func estimateBackupTime(totalBytes: Int64) -> TimeInterval {
-            // Use decimal MB to match user expectations
             let totalMB = Double(totalBytes) / (1000 * 1000)
-
-            // Use realistic speeds based on actual performance:
-            // We've already factored in real-world speeds in the base estimates
-            // Only apply small additional overhead for file system operations
-            let realWorldFactor = 0.95 // 95% of theoretical (5% overhead for file operations)
-
-            // Copy time with realistic speed
+            let realWorldFactor = 0.95
             let effectiveCopySpeed = estimatedWriteSpeed * realWorldFactor
             let copyTime = totalMB / effectiveCopySpeed
-
-            // Verify time is much faster due to caching and sequential reads
-            // Typically 30-40% of copy time on fast drives
             let verifyTime = copyTime * 0.35
-
             return copyTime + verifyTime
         }
 
         func formattedEstimate(totalBytes: Int64) -> String {
             let totalSeconds = estimateBackupTime(totalBytes: totalBytes)
-
-            // Provide a range (±20%) for more honest estimates
             let minSeconds = totalSeconds * 0.8
             let maxSeconds = totalSeconds * 1.2
 
@@ -174,30 +151,33 @@ class DriveAnalyzer {
                 let minHours = minSeconds / 3600
                 let maxHours = maxSeconds / 3600
                 if maxHours < 1.5 {
-                    // For times under 1.5 hours, show in minutes
                     let minMinutes = Int(minSeconds / 60)
                     let maxMinutes = Int(ceil(maxSeconds / 60))
                     return "\(minMinutes)-\(maxMinutes) minutes"
                 } else if maxHours < 10 {
-                    // For reasonable times, show hours with one decimal
                     return String(format: "%.1f-%.1f hours", minHours, maxHours)
                 } else {
-                    // For very long times, just show hours
                     return String(format: "%.0f-%.0f hours", minHours, maxHours)
                 }
             }
         }
     }
 
-    // MARK: - IOKit Detection
+    // MARK: - Cache
+
+    static let cache = DriveInfoCache()
+
+    // MARK: - Drive Analysis
 
     static func analyzeDrive(at url: URL) -> DriveInfo? {
-        // Get volume attributes
         let volumeAttributes = getVolumeAttributes(for: url)
 
-        // First check if it's a network volume
+        if let uuid = volumeAttributes.uuid, let cached = cache.get(volumeUUID: uuid) {
+            return cached
+        }
+
         if isNetworkVolume(url: url) {
-            return DriveInfo(
+            let info = DriveInfo(
                 mountPath: url,
                 connectionType: .network,
                 isSSD: false,
@@ -212,44 +192,28 @@ class DriveAnalyzer {
                 freeSpace: volumeAttributes.freeSpace,
                 driveType: .networkDrive
             )
+            cache.store(info)
+            return info
         }
 
-        // Get the BSD name for the volume
         guard let bsdName = getBSDName(for: url) else {
             return nil
         }
 
-        // Detect connection type and drive info
-        let connectionType = detectConnectionType(bsdName: bsdName)
-        let isSSD = detectIfSSD(bsdName: bsdName)
-        let deviceName = getDeviceName(bsdName: bsdName) ?? url.lastPathComponent
+        let props = gatherDriveProperties(bsdName: bsdName, fallbackName: url.lastPathComponent)
 
-        // Get base speeds from connection type
-        let writeSpeed = connectionType.estimatedWriteSpeedMBps
-        let readSpeed = connectionType.estimatedReadSpeedMBps
-
-        // Note: We're NOT limiting speeds for HDDs anymore since modern external
-        // SSDs can be very fast over TB3/4/5, and our SSD detection might not
-        // catch all SSDs (especially external ones)
-
-        let protocolDetails = getProtocolDetails(bsdName: bsdName)
-        let hardwareInfo = getHardwareInfo(bsdName: bsdName)
-
-        // Smart drive type detection
         let driveType = detectDriveType(
-            deviceName: deviceName,
-            deviceModel: hardwareInfo.model,
-            connectionType: connectionType,
-            isSSD: isSSD,
+            deviceName: props.deviceName,
+            deviceModel: props.deviceModel,
+            connectionType: props.connectionType,
+            isSSD: props.isSSD,
             capacity: volumeAttributes.totalCapacity,
             bsdName: bsdName
         )
 
-        // Override connection type for memory cards
-        var finalConnectionType = connectionType
+        var finalConnectionType = props.connectionType
         if driveType == .cameraCard || driveType == .cardReader {
-            // Check if it's SD or CFexpress based on size and model
-            if let model = hardwareInfo.model?.lowercased() {
+            if let model = props.deviceModel?.lowercased() {
                 if model.contains("cfexpress") || model.contains("cfe") {
                     finalConnectionType = .cfCard
                 } else if model.contains("sd") || volumeAttributes.totalCapacity <= 512_000_000_000 {
@@ -260,617 +224,130 @@ class DriveAnalyzer {
             }
         }
 
-        return DriveInfo(
+        let info = DriveInfo(
             mountPath: url,
             connectionType: finalConnectionType,
-            isSSD: isSSD,
-            deviceName: deviceName,
-            protocolDetails: protocolDetails,
-            estimatedWriteSpeed: writeSpeed,
-            estimatedReadSpeed: readSpeed,
+            isSSD: props.isSSD,
+            deviceName: props.deviceName,
+            protocolDetails: props.protocolDetails,
+            estimatedWriteSpeed: props.connectionType.estimatedWriteSpeedMBps,
+            estimatedReadSpeed: props.connectionType.estimatedReadSpeedMBps,
             volumeUUID: volumeAttributes.uuid,
-            hardwareSerial: hardwareInfo.serial,
-            deviceModel: hardwareInfo.model,
+            hardwareSerial: props.hardwareSerial,
+            deviceModel: props.deviceModel,
             totalCapacity: volumeAttributes.totalCapacity,
             freeSpace: volumeAttributes.freeSpace,
             driveType: driveType
         )
+        cache.store(info)
+        return info
     }
 
-    private static func isNetworkVolume(url: URL) -> Bool {
-        var isNetwork = false
+    // MARK: - Consolidated IOKit Lookup
 
-        do {
-            let resourceValues = try url.resourceValues(forKeys: [.volumeIsLocalKey])
-            if let isLocal = resourceValues.volumeIsLocal {
-                isNetwork = !isLocal
-            }
-        } catch {
-            ApplicationLogger.shared.debug("Error checking if volume is network: \(error)", category: .hardware)
-        }
-
-        return isNetwork
+    private struct DriveProperties {
+        let connectionType: ConnectionType
+        let isSSD: Bool
+        let deviceName: String
+        let protocolDetails: String
+        let hardwareSerial: String?
+        let deviceModel: String?
     }
 
-    static func getBSDName(for url: URL) -> String? {
-        // Use DiskArbitration to get BSD name from mount point
-        guard let session = DASessionCreate(kCFAllocatorDefault) else {
-            ApplicationLogger.shared.debug("Failed to create DA session", category: .hardware)
-            return nil
+    /// Single IOKit lookup replacing 4 separate IOServiceGetMatchingServices("IOMedia") scans.
+    private static func gatherDriveProperties(bsdName: String, fallbackName: String) -> DriveProperties {
+        let service = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOBSDNameMatching(kIOMainPortDefault, 0, bsdName)
+        )
+
+        guard service != 0 else {
+            return DriveProperties(
+                connectionType: .unknown,
+                isSSD: false,
+                deviceName: fallbackName,
+                protocolDetails: "Direct Attached",
+                hardwareSerial: nil,
+                deviceModel: nil
+            )
         }
 
-        // Get the device from the URL
-        guard let disk = DADiskCreateFromVolumePath(kCFAllocatorDefault, session, url as CFURL) else {
-            ApplicationLogger.shared.debug("Failed to create disk from path: \(url.path)", category: .hardware)
+        defer { IOObjectRelease(service) }
 
-            // Fallback: Try to get BSD name for system volume
-            if url.path.hasPrefix("/System") || url.path.hasPrefix("/Users") || url.path == "/" {
-                ApplicationLogger.shared.debug("Detected system path, using fallback", category: .hardware)
-                // For system volume, typically disk1s1 or similar
-                // Try to find it via mount command
-                return getSystemVolumeBSDName()
-            }
-            return nil
+        var serial: String?
+        var model: String?
+        var properties: Unmanaged<CFMutableDictionary>?
+        if IORegistryEntryCreateCFProperties(service, &properties, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+           let props = properties?.takeRetainedValue() as? [String: Any] {
+            serial = props["Serial Number"] as? String
+                ?? props["USB Serial Number"] as? String
+                ?? props["Device Serial"] as? String
+            model = props["Model"] as? String
+                ?? props["Device Model"] as? String
+                ?? props["Product Name"] as? String
         }
 
-        guard let diskInfo = DADiskCopyDescription(disk) as? [String: Any] else {
-            ApplicationLogger.shared.debug("Failed to get disk description", category: .hardware)
-            return nil
-        }
-
-        ApplicationLogger.shared.debug("Disk info: \(diskInfo)", category: .hardware)
-
-        if let bsdName = diskInfo["DAMediaBSDName"] as? String {
-            ApplicationLogger.shared.debug("Found BSD name: \(bsdName)", category: .hardware)
-            return bsdName
-        } else if let volumePath = diskInfo["DAVolumePath"] as? URL {
-            ApplicationLogger.shared.debug("Volume path: \(volumePath)", category: .hardware)
-            // Try another approach for system volumes
-            if volumePath.path == "/" || url.path.hasPrefix(volumePath.path) {
-                return getSystemVolumeBSDName()
-            }
-        }
-
-        return nil
-    }
-
-    private static func getSystemVolumeBSDName() -> String? {
-        // For macOS system volume, try to find the BSD name
-        // This is a simplified approach - typically the system is on disk1s1 or similar
-
-        // Try using statfs to get mount info
-        var statInfo = statfs()
-        if statfs("/", &statInfo) == 0 {
-            let device = withUnsafePointer(to: &statInfo.f_mntfromname) { ptr in
-                ptr.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) { cString in
-                    String(cString: cString)
-                }
-            }
-            ApplicationLogger.shared.debug("System volume device from statfs: \(device)", category: .hardware)
-
-            // Extract BSD name from device path (e.g., /dev/disk1s1 -> disk1s1)
-            if device.hasPrefix("/dev/") {
-                let bsdName = String(device.dropFirst(5))
-                // Remove partition suffix for whole disk
-                if let baseRange = bsdName.range(of: "s[0-9]+$", options: .regularExpression) {
-                    return String(bsdName[..<baseRange.lowerBound])
-                }
-                return bsdName
+        var isSSD = false
+        if let characteristics = IORegistryEntryCreateCFProperty(
+            service, "Device Characteristics" as CFString, kCFAllocatorDefault, 0
+        ) {
+            if let dict = characteristics.takeRetainedValue() as? [String: Any],
+               let mediumType = dict["Medium Type"] as? String {
+                let lower = mediumType.lowercased()
+                isSSD = lower.contains("solid state") || lower.contains("ssd")
             }
         }
 
-        // Fallback: assume internal drive
-        ApplicationLogger.shared.debug("Using fallback BSD name for system volume", category: .hardware)
-        return "disk0" // Common for internal SSDs
-    }
+        var deviceName = fallbackName
+        var protocolDetails = "Direct Attached"
 
-    private static func detectConnectionType(bsdName: String) -> ConnectionType {
-        var connectionType = ConnectionType.unknown
+        var parent: io_object_t = 0
+        if IORegistryEntryGetParentEntry(service, kIOServicePlane, &parent) == KERN_SUCCESS {
+            defer { IOObjectRelease(parent) }
 
-        // Create an iterator for IO services
-        var iterator: io_iterator_t = 0
-        let matching = IOServiceMatching("IOMedia")
-        let result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator)
-
-        guard result == KERN_SUCCESS else { return .unknown }
-        defer { IOObjectRelease(iterator) }
-
-        while case let service = IOIteratorNext(iterator), service != 0 {
-            defer { IOObjectRelease(service) }
-
-            // Check if this is our disk
-            if let bsdNameProp = IORegistryEntryCreateCFProperty(
-                service, "BSD Name" as CFString, kCFAllocatorDefault, 0
-            ) {
-                let currentBSDName = bsdNameProp.takeRetainedValue() as? String
-
-                if currentBSDName == bsdName {
-                    // Found our disk, now traverse up to find the controller
-                    connectionType = findConnectionType(for: service)
+            let nameKeys = ["Product Name", "USB Product Name", "Model", "kUSBProductString"]
+            for key in nameKeys {
+                if let prop = IORegistryEntryCreateCFProperty(parent, key as CFString, kCFAllocatorDefault, 0),
+                   let name = prop.takeRetainedValue() as? String {
+                    deviceName = name
                     break
                 }
             }
+
+            if !isSSD {
+                if let modelProp = IORegistryEntryCreateCFProperty(parent, "Model" as CFString, kCFAllocatorDefault, 0),
+                   let modelString = modelProp.takeRetainedValue() as? String {
+                    let lower = modelString.lowercased()
+                    isSSD = lower.contains("ssd") || lower.contains("solid") || lower.contains("nvme")
+                }
+            }
+
+            if let linkSpeed = IORegistryEntryCreateCFProperty(parent, "Link Speed" as CFString, kCFAllocatorDefault, 0),
+               let speed = linkSpeed.takeRetainedValue() as? String {
+                protocolDetails = speed
+            }
+            if let negotiatedSpeed = IORegistryEntryCreateCFProperty(parent, "Negotiated Link Speed" as CFString, kCFAllocatorDefault, 0),
+               let speed = negotiatedSpeed.takeRetainedValue() as? Int {
+                let gbps = Double(speed) / 1000.0
+                protocolDetails = String(format: "%.1f Gbps", gbps)
+            }
         }
 
-        return connectionType
+        let connectionType = findConnectionType(for: service)
+
+        return DriveProperties(
+            connectionType: connectionType,
+            isSSD: isSSD,
+            deviceName: deviceName,
+            protocolDetails: protocolDetails,
+            hardwareSerial: serial,
+            deviceModel: model
+        )
     }
 
-    private static func findConnectionType(for service: io_object_t) -> ConnectionType {
-        var parent: io_object_t = 0
-        var foundPCI = false
-        var foundThunderbolt = false
+    // MARK: - Smart Drive Type Detection (internal for testing)
 
-        // Traverse up the IO registry tree
-        var currentService = service
-        IOObjectRetain(currentService)
-
-        while IORegistryEntryGetParentEntry(currentService, kIOServicePlane, &parent) == KERN_SUCCESS {
-            defer {
-                IOObjectRelease(currentService)
-                currentService = parent
-            }
-
-            // Check class name first
-            var className = [CChar](repeating: 0, count: 128)
-            IOObjectGetClass(parent, &className)
-            let classString = String(cString: className)
-
-            // Debug output
-            ApplicationLogger.shared.debug("Checking class: \(classString)", category: .hardware)
-
-            // Check for Thunderbolt in class name
-            if classString.contains("Thunderbolt") || classString.contains("Thunder") {
-                foundThunderbolt = true
-                ApplicationLogger.shared.debug("Found Thunderbolt in class name", category: .hardware)
-            }
-
-            // Check Protocol Characteristics
-            if let protocolChar = IORegistryEntryCreateCFProperty(
-                parent, "Protocol Characteristics" as CFString, kCFAllocatorDefault, 0
-            ) {
-                if let dict = protocolChar.takeRetainedValue() as? [String: Any] {
-                    ApplicationLogger.shared.debug("Protocol Characteristics: \(dict)", category: .hardware)
-
-                    if let physical = dict["Physical Interconnect"] as? String {
-                        ApplicationLogger.shared.debug("Physical Interconnect: \(physical)", category: .hardware)
-
-                        // Check if it's external PCI-Express (likely Thunderbolt)
-                        if let location = dict["Physical Interconnect Location"] as? String {
-                            ApplicationLogger.shared.debug("Physical Location: \(location)", category: .hardware)
-                            if location == "External" && physical.contains("PCI") {
-                                ApplicationLogger.shared.debug("External PCI-Express detected - this IS Thunderbolt", category: .hardware)
-                                // External PCI-Express is ALWAYS Thunderbolt (TB3/4/5)
-                                // Try to determine version by looking for speed info
-                                return detectThunderboltVersion(for: parent)
-                            }
-                        }
-
-                        if physical.contains("Thunderbolt") || physical.contains("Thunder") {
-                            ApplicationLogger.shared.debug("Detected Thunderbolt via Protocol Characteristics", category: .hardware)
-                            return .thunderbolt3
-                        } else if physical.contains("USB") {
-                            ApplicationLogger.shared.debug("Detected USB via Protocol Characteristics", category: .hardware)
-                            return detectUSBSpeed(for: parent)
-                        } else if physical.contains("PCI") {
-                            // PCI without "External" location might be internal
-                            if let location = dict["Physical Interconnect Location"] as? String,
-                               location == "Internal"
-                            {
-                                ApplicationLogger.shared.debug("Internal PCI-Express - Internal drive", category: .hardware)
-                                return .internalDrive
-                            }
-                            foundPCI = true
-                            // Don't return immediately - might be TB over PCI
-                        } else if physical.contains("SATA") {
-                            ApplicationLogger.shared.debug("Detected SATA - Internal drive", category: .hardware)
-                            return .internalDrive
-                        }
-                    }
-                }
-            }
-
-            // Check for device type properties
-            if let deviceType = IORegistryEntryCreateCFProperty(
-                parent, "Device Type" as CFString, kCFAllocatorDefault, 0
-            ) {
-                if let typeString = deviceType.takeRetainedValue() as? String {
-                    ApplicationLogger.shared.debug("Device Type: \(typeString)", category: .hardware)
-                }
-            }
-
-            // Check specific Thunderbolt properties
-            if let tbSpeed = IORegistryEntryCreateCFProperty(
-                parent, "Thunderbolt Speed" as CFString, kCFAllocatorDefault, 0
-            ) {
-                ApplicationLogger.shared.debug("Found Thunderbolt Speed property: \(tbSpeed)", category: .hardware)
-                foundThunderbolt = true
-            }
-
-            // Check link speed to determine TB version
-            if let linkSpeed = IORegistryEntryCreateCFProperty(
-                parent, "Link Speed" as CFString, kCFAllocatorDefault, 0
-            ) {
-                ApplicationLogger.shared.debug("Found Link Speed: \(linkSpeed)", category: .hardware)
-                if let speed = linkSpeed.takeRetainedValue() as? Int {
-                    if speed >= 80000 { // 80 Gbps = TB5
-                        ApplicationLogger.shared.debug("Detected Thunderbolt 5 (80+ Gbps)", category: .hardware)
-                        return .thunderbolt5
-                    } else if speed >= 40000 { // 40 Gbps = TB4
-                        ApplicationLogger.shared.debug("Detected Thunderbolt 4 (40 Gbps)", category: .hardware)
-                        return .thunderbolt4
-                    } else if speed >= 20000 { // 20 Gbps = TB3
-                        foundThunderbolt = true
-                    }
-                }
-            }
-
-            // Check for USB in class name
-            if classString.contains("USB") {
-                ApplicationLogger.shared.debug("Detected USB via class name", category: .hardware)
-                return detectUSBSpeed(for: parent)
-            }
-
-            // Check for NVMe (usually internal but could be TB)
-            if classString.contains("NVMe") {
-                if foundThunderbolt {
-                    ApplicationLogger.shared.debug("NVMe over Thunderbolt", category: .hardware)
-                    return .thunderbolt3
-                }
-                // Keep checking - might find TB higher up
-            }
-        }
-
-        IOObjectRelease(currentService)
-
-        // Final decision based on what we found
-        if foundThunderbolt {
-            ApplicationLogger.shared.debug("Final decision: Thunderbolt", category: .hardware)
-            return .thunderbolt3
-        } else if foundPCI {
-            // PCI alone doesn't mean internal - could still be external
-            ApplicationLogger.shared.debug("Final decision: Unknown (PCI but unclear if external)", category: .hardware)
-            return .unknown
-        }
-
-        ApplicationLogger.shared.debug("Final decision: Unknown", category: .hardware)
-        return .unknown
-    }
-
-    private static func detectThunderboltVersion(for service: io_object_t) -> ConnectionType {
-        // First check if there's a TB5 controller in the system
-        if isThunderbolt5SystemPresent() {
-            ApplicationLogger.shared.debug("TB5 controller detected in system, assuming TB5 for external PCI-Express", category: .hardware)
-            return .thunderbolt5
-        }
-
-        // Try to determine TB version by looking at link speed or other properties
-        var parent: io_object_t = 0
-        var currentService = service
-        IOObjectRetain(currentService)
-
-        var foundJHL9580 = false // Intel TB5 controller
-
-        // Look up the tree for speed indicators
-        while IORegistryEntryGetParentEntry(currentService, kIOServicePlane, &parent) == KERN_SUCCESS {
-            defer {
-                IOObjectRelease(currentService)
-                currentService = parent
-            }
-
-            // Check class name for TB5 controllers
-            var className = [CChar](repeating: 0, count: 128)
-            IOObjectGetClass(parent, &className)
-            let classString = String(cString: className)
-
-            // Check for known TB5 controllers
-            if classString.contains("JHL9580") || classString.contains("JHL9480") {
-                ApplicationLogger.shared.debug("Found TB5 controller (JHL9580/9480)", category: .hardware)
-                foundJHL9580 = true
-                // Continue searching for more specific properties
-            }
-
-            // Check for IOPCIExpressLinkCapabilities which might indicate speed
-            if let linkCap = IORegistryEntryCreateCFProperty(
-                parent, "IOPCIExpressLinkCapabilities" as CFString, kCFAllocatorDefault, 0
-            ) {
-                // This is a bitmask that includes link speed info
-                if let cap = linkCap.takeRetainedValue() as? Int {
-                    ApplicationLogger.shared.debug("Found PCIe Link Capabilities: \(cap)", category: .hardware)
-                    // PCIe Gen 5 (used by TB5) has specific capability bits
-                    // Bit 0-3: Max Link Speed (0x5 = Gen5)
-                    let maxSpeed = cap & 0xF
-                    if maxSpeed >= 5 {
-                        ApplicationLogger.shared.debug("PCIe Gen 5+ detected - likely TB5", category: .hardware)
-                        IOObjectRelease(currentService)
-                        return .thunderbolt5
-                    }
-                }
-            }
-
-            // Check for link speed properties that indicate TB version
-            if let linkSpeed = IORegistryEntryCreateCFProperty(
-                parent, "Link Speed" as CFString, kCFAllocatorDefault, 0
-            ) {
-                ApplicationLogger.shared.debug("Found Link Speed in TB detection: \(linkSpeed)", category: .hardware)
-                if let speed = linkSpeed.takeRetainedValue() as? Int {
-                    if speed >= 80000 { // 80 Gbps = TB5
-                        ApplicationLogger.shared.debug("Detected Thunderbolt 5 (80+ Gbps)", category: .hardware)
-                        IOObjectRelease(currentService)
-                        return .thunderbolt5
-                    } else if speed >= 40000 { // 40 Gbps = TB4
-                        ApplicationLogger.shared.debug("Detected Thunderbolt 4 (40 Gbps)", category: .hardware)
-                        IOObjectRelease(currentService)
-                        return .thunderbolt4
-                    }
-                }
-            }
-
-            // Check for Negotiated Link Speed
-            if let negotiatedSpeed = IORegistryEntryCreateCFProperty(
-                parent, "Negotiated Link Speed" as CFString, kCFAllocatorDefault, 0
-            ) {
-                ApplicationLogger.shared.debug("Found Negotiated Link Speed: \(negotiatedSpeed)", category: .hardware)
-                if let speed = negotiatedSpeed.takeRetainedValue() as? Int {
-                    // Speed might be in Mbps
-                    if speed >= 80000 { // 80 Gbps
-                        IOObjectRelease(currentService)
-                        return .thunderbolt5
-                    } else if speed >= 40000 { // 40 Gbps
-                        IOObjectRelease(currentService)
-                        return .thunderbolt4
-                    }
-                }
-            }
-
-            // Check for TB-specific properties
-            if let tbGen = IORegistryEntryCreateCFProperty(
-                parent, "Thunderbolt Generation" as CFString, kCFAllocatorDefault, 0
-            ) {
-                if let gen = tbGen.takeRetainedValue() as? Int {
-                    ApplicationLogger.shared.debug("Found Thunderbolt Generation: \(gen)", category: .hardware)
-                    IOObjectRelease(currentService)
-                    switch gen {
-                    case 5: return .thunderbolt5
-                    case 4: return .thunderbolt4
-                    default: return .thunderbolt3
-                    }
-                }
-            }
-        }
-
-        IOObjectRelease(currentService)
-
-        // If we found a TB5 controller, return TB5
-        if foundJHL9580 {
-            ApplicationLogger.shared.debug("Detected TB5 based on JHL9580 controller", category: .hardware)
-            return .thunderbolt5
-        }
-
-        // Default to TB3 if we can't determine version
-        // (External PCI-Express is definitely Thunderbolt of some kind)
-        ApplicationLogger.shared.debug("Defaulting to Thunderbolt 3", category: .hardware)
-        return .thunderbolt3
-    }
-
-    private static func isThunderbolt5SystemPresent() -> Bool {
-        // Check if there's a TB5 controller anywhere in the system
-        var iterator: io_iterator_t = 0
-
-        // Search for Intel JHL9580 TB5 controller
-        let matching = IOServiceMatching("IOThunderboltSwitchIntelJHL9580")
-        let result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator)
-
-        guard result == KERN_SUCCESS else { return false }
-        defer { IOObjectRelease(iterator) }
-
-        // If we find any TB5 controller, return true
-        if IOIteratorNext(iterator) != 0 {
-            ApplicationLogger.shared.debug("Found IOThunderboltSwitchIntelJHL9580 (TB5) in system", category: .hardware)
-            return true
-        }
-
-        // Also check for JHL9480 (another TB5 variant)
-        let matching2 = IOServiceMatching("IOThunderboltSwitchIntelJHL9480")
-        var iterator2: io_iterator_t = 0
-        let result2 = IOServiceGetMatchingServices(kIOMainPortDefault, matching2, &iterator2)
-
-        guard result2 == KERN_SUCCESS else { return false }
-        defer { IOObjectRelease(iterator2) }
-
-        if IOIteratorNext(iterator2) != 0 {
-            ApplicationLogger.shared.debug("Found IOThunderboltSwitchIntelJHL9480 (TB5) in system", category: .hardware)
-            return true
-        }
-
-        return false
-    }
-
-    private static func detectUSBSpeed(for service: io_object_t) -> ConnectionType {
-        // Check for USB speed property
-        if let speedProp = IORegistryEntryCreateCFProperty(
-            service, "USB Speed" as CFString, kCFAllocatorDefault, 0
-        ) {
-            if let speed = speedProp.takeRetainedValue() as? Int {
-                // USB speeds in IOKit (rough mapping)
-                switch speed {
-                case 0 ... 1: return .usb2 // Low/Full speed
-                case 2: return .usb2 // High speed (480 Mbps)
-                case 3: return .usb30 // Super speed (5 Gbps)
-                case 4: return .usb31Gen2 // Super speed+ (10 Gbps)
-                case 5: return .usb32Gen2x2 // Super speed++ (20 Gbps)
-                default: return .usb30
-                }
-            }
-        }
-
-        // Try another approach with device speed
-        if let deviceSpeedProp = IORegistryEntryCreateCFProperty(
-            service, "Device Speed" as CFString, kCFAllocatorDefault, 0
-        ) {
-            if let speed = deviceSpeedProp.takeRetainedValue() as? Int {
-                switch speed {
-                case 0: return .usb2 // Low Speed
-                case 1: return .usb2 // Full Speed
-                case 2: return .usb2 // High Speed
-                case 3: return .usb30 // Super Speed
-                case 4: return .usb31Gen2 // Super Speed Plus
-                default: return .usb30
-                }
-            }
-        }
-
-        return .usb30 // Default to USB 3.0 if we can't determine
-    }
-
-    private static func detectIfSSD(bsdName: String) -> Bool {
-        // Check for SSD characteristics
-        var iterator: io_iterator_t = 0
-        let matching = IOServiceMatching("IOMedia")
-        let result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator)
-
-        guard result == KERN_SUCCESS else { return false }
-        defer { IOObjectRelease(iterator) }
-
-        while case let service = IOIteratorNext(iterator), service != 0 {
-            defer { IOObjectRelease(service) }
-
-            if let prop = IORegistryEntryCreateCFProperty(
-                service, "BSD Name" as CFString, kCFAllocatorDefault, 0
-            ) {
-                let currentBSDName = prop.takeRetainedValue() as? String
-
-                if currentBSDName == bsdName {
-                    // Check device characteristics
-                    if let characteristics = IORegistryEntryCreateCFProperty(
-                        service, "Device Characteristics" as CFString, kCFAllocatorDefault, 0
-                    ) {
-                        if let dict = characteristics.takeRetainedValue() as? [String: Any] {
-                            // Check for SSD indicator
-                            if let mediumType = dict["Medium Type"] as? String {
-                                return mediumType.lowercased().contains("solid state")
-                                    || mediumType.lowercased().contains("ssd")
-                            }
-                        }
-                    }
-
-                    // Check parent device for model name
-                    var parent: io_object_t = 0
-                    if IORegistryEntryGetParentEntry(service, kIOServicePlane, &parent) == KERN_SUCCESS {
-                        defer { IOObjectRelease(parent) }
-
-                        if let model = IORegistryEntryCreateCFProperty(
-                            parent, "Model" as CFString, kCFAllocatorDefault, 0
-                        ) {
-                            if let modelString = model.takeRetainedValue() as? String {
-                                let lowerModel = modelString.lowercased()
-                                return lowerModel.contains("ssd") || lowerModel.contains("solid")
-                                    || lowerModel.contains("nvme")
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return false // Default to HDD if unknown
-    }
-
-    private static func getDeviceName(bsdName: String) -> String? {
-        // Try to get a friendly device name
-        var iterator: io_iterator_t = 0
-        let matching = IOServiceMatching("IOMedia")
-        let result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator)
-
-        guard result == KERN_SUCCESS else { return nil }
-        defer { IOObjectRelease(iterator) }
-
-        while case let service = IOIteratorNext(iterator), service != 0 {
-            defer { IOObjectRelease(service) }
-
-            if let prop = IORegistryEntryCreateCFProperty(
-                service, "BSD Name" as CFString, kCFAllocatorDefault, 0
-            ) {
-                let currentBSDName = prop.takeRetainedValue() as? String
-
-                if currentBSDName == bsdName {
-                    // Try to get the product name
-                    var parent: io_object_t = 0
-                    if IORegistryEntryGetParentEntry(service, kIOServicePlane, &parent) == KERN_SUCCESS {
-                        defer { IOObjectRelease(parent) }
-
-                        // Try various property names
-                        let propertyNames = ["Product Name", "USB Product Name", "Model", "kUSBProductString"]
-
-                        for propertyName in propertyNames {
-                            if let nameProp = IORegistryEntryCreateCFProperty(
-                                parent, propertyName as CFString, kCFAllocatorDefault, 0
-                            ) {
-                                if let name = nameProp.takeRetainedValue() as? String {
-                                    return name
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return nil
-    }
-
-    private static func getProtocolDetails(bsdName: String) -> String {
-        var details = ""
-
-        // Get more detailed protocol information
-        var iterator: io_iterator_t = 0
-        let matching = IOServiceMatching("IOMedia")
-        let result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator)
-
-        guard result == KERN_SUCCESS else { return "Unknown" }
-        defer { IOObjectRelease(iterator) }
-
-        while case let service = IOIteratorNext(iterator), service != 0 {
-            defer { IOObjectRelease(service) }
-
-            if let prop = IORegistryEntryCreateCFProperty(
-                service, "BSD Name" as CFString, kCFAllocatorDefault, 0
-            ) {
-                let currentBSDName = prop.takeRetainedValue() as? String
-
-                if currentBSDName == bsdName {
-                    var parent: io_object_t = 0
-                    if IORegistryEntryGetParentEntry(service, kIOServicePlane, &parent) == KERN_SUCCESS {
-                        defer { IOObjectRelease(parent) }
-
-                        // Get link speed if available
-                        if let linkSpeed = IORegistryEntryCreateCFProperty(
-                            parent, "Link Speed" as CFString, kCFAllocatorDefault, 0
-                        ) {
-                            if let speed = linkSpeed.takeRetainedValue() as? String {
-                                details = speed
-                            }
-                        }
-
-                        // Get negotiated link speed
-                        if let negotiatedSpeed = IORegistryEntryCreateCFProperty(
-                            parent, "Negotiated Link Speed" as CFString, kCFAllocatorDefault, 0
-                        ) {
-                            if let speed = negotiatedSpeed.takeRetainedValue() as? Int {
-                                let gbps = Double(speed) / 1000.0
-                                details = String(format: "%.1f Gbps", gbps)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return details.isEmpty ? "Direct Attached" : details
-    }
-
-    // MARK: - Smart Drive Type Detection
-
-    private static func detectDriveType(
+    static func detectDriveType(
         deviceName: String,
         deviceModel: String?,
         connectionType: ConnectionType,
@@ -881,7 +358,6 @@ class DriveAnalyzer {
         let lowerName = deviceName.lowercased()
         let lowerModel = deviceModel?.lowercased() ?? ""
 
-        // Check for camera brands (drive is still in camera)
         let camerabrands = [
             "canon", "nikon", "sony", "fujifilm", "fuji", "olympus", "panasonic", "leica", "hasselblad",
             "pentax",
@@ -892,7 +368,6 @@ class DriveAnalyzer {
             }
         }
 
-        // Check for memory card keywords
         let cardKeywords = [
             "sd card", "sdxc", "sdhc", "cfexpress", "cfe", "compactflash", "cf card", "memory card",
             "memstick",
@@ -903,7 +378,6 @@ class DriveAnalyzer {
             }
         }
 
-        // Check for card reader keywords
         let readerKeywords = [
             "card reader", "cardreader", "sd reader", "cf reader", "multi-card", "multicard",
         ]
@@ -913,27 +387,22 @@ class DriveAnalyzer {
             }
         }
 
-        // Check for memory card manufacturers
         let cardManufacturers = [
             "sandisk", "lexar", "prograde", "angelbird", "delkin", "sony tough", "transcend",
         ]
         for manufacturer in cardManufacturers {
             if lowerModel.contains(manufacturer) {
-                // Check if it's small enough to be a card (under 2TB)
                 if capacity <= 2_000_000_000_000 {
                     return .cameraCard
                 }
             }
         }
 
-        // Size-based detection for cards (32GB to 1TB typically)
         if capacity >= 32_000_000_000 && capacity <= 1_000_000_000_000 {
-            // Common card sizes: 32, 64, 128, 256, 512 GB, 1TB
             let gbSize = capacity / 1_000_000_000
             let commonCardSizes: [Int64] = [32, 64, 128, 256, 512, 1024]
             for size in commonCardSizes {
-                if gbSize >= size - 5 && gbSize <= size + 5 { // Allow some tolerance
-                    // Likely a memory card if it's one of these exact sizes
+                if gbSize >= size - 5 && gbSize <= size + 5 {
                     if connectionType == .usb2 || connectionType == .usb30 {
                         return .cardReader
                     }
@@ -941,7 +410,6 @@ class DriveAnalyzer {
             }
         }
 
-        // Check for portable SSD keywords
         let portableSSDKeywords = [
             "t5", "t7", "t9", "extreme pro", "extreme portable", "portable ssd", "nvme", "thunderbolt",
         ]
@@ -951,7 +419,6 @@ class DriveAnalyzer {
             }
         }
 
-        // Check for known portable drive manufacturers
         let portableDriveManufacturers = [
             "samsung portable", "sandisk extreme", "lacie", "g-drive", "g drive", "wd passport",
             "wd my passport", "seagate backup",
@@ -962,20 +429,17 @@ class DriveAnalyzer {
             }
         }
 
-        // Check by connection type and other properties
         switch connectionType {
         case .internalDrive:
             return .internalDrive
         case .network:
             return .networkDrive
         case .thunderbolt3, .thunderbolt4, .thunderbolt5:
-            // Thunderbolt drives are typically high-performance portable SSDs
             if isSSD {
                 return .portableSSD
             }
         case .usb30, .usb31Gen1, .usb31Gen2, .usb32Gen2x2:
-            // USB 3.x drives could be portable
-            if isSSD && capacity <= 4_000_000_000_000 { // 4TB or less
+            if isSSD && capacity <= 4_000_000_000_000 {
                 return .portableSSD
             } else if !isSSD {
                 return .externalHDD
@@ -984,7 +448,6 @@ class DriveAnalyzer {
             break
         }
 
-        // Default based on connection and type
         if connectionType == .internalDrive {
             return .internalDrive
         } else if isSSD {
@@ -1007,7 +470,6 @@ class DriveAnalyzer {
         var totalCapacity: Int64 = 0
         var freeSpace: Int64 = 0
 
-        // Get volume UUID and capacity info
         do {
             let resourceKeys: [URLResourceKey] = [
                 .volumeUUIDStringKey,
@@ -1024,53 +486,5 @@ class DriveAnalyzer {
         }
 
         return VolumeAttributes(uuid: uuid, totalCapacity: totalCapacity, freeSpace: freeSpace)
-    }
-
-    // MARK: - Hardware Info
-
-    private struct HardwareInfo {
-        let serial: String?
-        let model: String?
-    }
-
-    private static func getHardwareInfo(bsdName: String) -> HardwareInfo {
-        var serial: String?
-        var model: String?
-
-        // Get IOKit service for the device
-        let service = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOBSDNameMatching(kIOMainPortDefault, 0, bsdName)
-        )
-
-        guard service != 0 else {
-            return HardwareInfo(serial: nil, model: nil)
-        }
-
-        defer { IOObjectRelease(service) }
-
-        // Try to get serial number and model
-        var properties: Unmanaged<CFMutableDictionary>?
-        let result = IORegistryEntryCreateCFProperties(
-            service,
-            &properties,
-            kCFAllocatorDefault,
-            0
-        )
-
-        if result == KERN_SUCCESS, let props = properties?.takeRetainedValue() as? [String: Any] {
-            // Look for serial number
-            serial =
-                props["Serial Number"] as? String ?? props["USB Serial Number"] as? String ?? props[
-                    "Device Serial"
-                ] as? String
-
-            // Look for model
-            model =
-                props["Model"] as? String ?? props["Device Model"] as? String ?? props["Product Name"]
-                    as? String
-        }
-
-        return HardwareInfo(serial: serial, model: model)
     }
 }

--- a/ImageIntact/Models/DriveAnalyzer.swift
+++ b/ImageIntact/Models/DriveAnalyzer.swift
@@ -123,6 +123,14 @@ class DriveAnalyzer {
 
         let driveType: DriveType
 
+        func withFreshVolumeAttributes(url: URL, totalCapacity: Int64, freeSpace: Int64) -> DriveInfo {
+            DriveInfo(mountPath: url, connectionType: connectionType, isSSD: isSSD, deviceName: deviceName,
+                      protocolDetails: protocolDetails, estimatedWriteSpeed: estimatedWriteSpeed,
+                      estimatedReadSpeed: estimatedReadSpeed, volumeUUID: volumeUUID,
+                      hardwareSerial: hardwareSerial, deviceModel: deviceModel,
+                      totalCapacity: totalCapacity, freeSpace: freeSpace, driveType: driveType)
+        }
+
         func estimateBackupTime(totalBytes: Int64) -> TimeInterval {
             let totalMB = Double(totalBytes) / (1000 * 1000)
             let realWorldFactor = 0.95
@@ -173,7 +181,9 @@ class DriveAnalyzer {
         let volumeAttributes = getVolumeAttributes(for: url)
 
         if let uuid = volumeAttributes.uuid, let cached = cache.get(volumeUUID: uuid) {
-            return cached
+            return cached.withFreshVolumeAttributes(
+                url: url, totalCapacity: volumeAttributes.totalCapacity, freeSpace: volumeAttributes.freeSpace
+            )
         }
 
         if isNetworkVolume(url: url) {

--- a/ImageIntact/Models/DriveAnalyzerIOKit.swift
+++ b/ImageIntact/Models/DriveAnalyzerIOKit.swift
@@ -82,21 +82,21 @@ extension DriveAnalyzer {
     // MARK: - Connection Type Detection
 
     static func findConnectionType(for service: io_object_t) -> ConnectionType {
-        var parent: io_object_t = 0
         var foundPCI = false
         var foundThunderbolt = false
+        var result: ConnectionType?
 
         var currentService = service
         IOObjectRetain(currentService)
 
+        var parent: io_object_t = 0
+
         while IORegistryEntryGetParentEntry(currentService, kIOServicePlane, &parent) == KERN_SUCCESS {
-            defer {
-                IOObjectRelease(currentService)
-                currentService = parent
-            }
+            IOObjectRelease(currentService)
+            currentService = parent
 
             var className = [CChar](repeating: 0, count: 128)
-            IOObjectGetClass(parent, &className)
+            IOObjectGetClass(currentService, &className)
             let classString = String(cString: className)
 
             ApplicationLogger.shared.debug("Checking class: \(classString)", category: .hardware)
@@ -107,7 +107,7 @@ extension DriveAnalyzer {
             }
 
             if let protocolChar = IORegistryEntryCreateCFProperty(
-                parent, "Protocol Characteristics" as CFString, kCFAllocatorDefault, 0
+                currentService, "Protocol Characteristics" as CFString, kCFAllocatorDefault, 0
             ) {
                 if let dict = protocolChar.takeRetainedValue() as? [String: Any] {
                     ApplicationLogger.shared.debug("Protocol Characteristics: \(dict)", category: .hardware)
@@ -119,34 +119,39 @@ extension DriveAnalyzer {
                             ApplicationLogger.shared.debug("Physical Location: \(location)", category: .hardware)
                             if location == "External" && physical.contains("PCI") {
                                 ApplicationLogger.shared.debug("External PCI-Express detected - this IS Thunderbolt", category: .hardware)
-                                return detectThunderboltVersion(for: parent)
+                                result = detectThunderboltVersion(for: currentService)
+                                break
                             }
                         }
 
                         if physical.contains("Thunderbolt") || physical.contains("Thunder") {
                             ApplicationLogger.shared.debug("Detected Thunderbolt via Protocol Characteristics", category: .hardware)
-                            return .thunderbolt3
+                            result = .thunderbolt3
+                            break
                         } else if physical.contains("USB") {
                             ApplicationLogger.shared.debug("Detected USB via Protocol Characteristics", category: .hardware)
-                            return detectUSBSpeed(for: parent)
+                            result = detectUSBSpeed(for: currentService)
+                            break
                         } else if physical.contains("PCI") {
                             if let location = dict["Physical Interconnect Location"] as? String,
                                location == "Internal"
                             {
                                 ApplicationLogger.shared.debug("Internal PCI-Express - Internal drive", category: .hardware)
-                                return .internalDrive
+                                result = .internalDrive
+                                break
                             }
                             foundPCI = true
                         } else if physical.contains("SATA") {
                             ApplicationLogger.shared.debug("Detected SATA - Internal drive", category: .hardware)
-                            return .internalDrive
+                            result = .internalDrive
+                            break
                         }
                     }
                 }
             }
 
             if let deviceType = IORegistryEntryCreateCFProperty(
-                parent, "Device Type" as CFString, kCFAllocatorDefault, 0
+                currentService, "Device Type" as CFString, kCFAllocatorDefault, 0
             ) {
                 if let typeString = deviceType.takeRetainedValue() as? String {
                     ApplicationLogger.shared.debug("Device Type: \(typeString)", category: .hardware)
@@ -154,23 +159,25 @@ extension DriveAnalyzer {
             }
 
             if let tbSpeed = IORegistryEntryCreateCFProperty(
-                parent, "Thunderbolt Speed" as CFString, kCFAllocatorDefault, 0
+                currentService, "Thunderbolt Speed" as CFString, kCFAllocatorDefault, 0
             ) {
                 ApplicationLogger.shared.debug("Found Thunderbolt Speed property: \(tbSpeed)", category: .hardware)
                 foundThunderbolt = true
             }
 
             if let linkSpeed = IORegistryEntryCreateCFProperty(
-                parent, "Link Speed" as CFString, kCFAllocatorDefault, 0
+                currentService, "Link Speed" as CFString, kCFAllocatorDefault, 0
             ) {
                 ApplicationLogger.shared.debug("Found Link Speed: \(linkSpeed)", category: .hardware)
                 if let speed = linkSpeed.takeRetainedValue() as? Int {
                     if speed >= 80000 {
                         ApplicationLogger.shared.debug("Detected Thunderbolt 5 (80+ Gbps)", category: .hardware)
-                        return .thunderbolt5
+                        result = .thunderbolt5
+                        break
                     } else if speed >= 40000 {
                         ApplicationLogger.shared.debug("Detected Thunderbolt 4 (40 Gbps)", category: .hardware)
-                        return .thunderbolt4
+                        result = .thunderbolt4
+                        break
                     } else if speed >= 20000 {
                         foundThunderbolt = true
                     }
@@ -179,18 +186,24 @@ extension DriveAnalyzer {
 
             if classString.contains("USB") {
                 ApplicationLogger.shared.debug("Detected USB via class name", category: .hardware)
-                return detectUSBSpeed(for: parent)
+                result = detectUSBSpeed(for: currentService)
+                break
             }
 
             if classString.contains("NVMe") {
                 if foundThunderbolt {
                     ApplicationLogger.shared.debug("NVMe over Thunderbolt", category: .hardware)
-                    return .thunderbolt3
+                    result = .thunderbolt3
+                    break
                 }
             }
         }
 
         IOObjectRelease(currentService)
+
+        if let result = result {
+            return result
+        }
 
         if foundThunderbolt {
             ApplicationLogger.shared.debug("Final decision: Thunderbolt", category: .hardware)
@@ -212,20 +225,19 @@ extension DriveAnalyzer {
             return .thunderbolt5
         }
 
-        var parent: io_object_t = 0
         var currentService = service
         IOObjectRetain(currentService)
 
         var foundJHL9580 = false
+        var result: ConnectionType?
+        var parent: io_object_t = 0
 
         while IORegistryEntryGetParentEntry(currentService, kIOServicePlane, &parent) == KERN_SUCCESS {
-            defer {
-                IOObjectRelease(currentService)
-                currentService = parent
-            }
+            IOObjectRelease(currentService)
+            currentService = parent
 
             var className = [CChar](repeating: 0, count: 128)
-            IOObjectGetClass(parent, &className)
+            IOObjectGetClass(currentService, &className)
             let classString = String(cString: className)
 
             if classString.contains("JHL9580") || classString.contains("JHL9480") {
@@ -234,67 +246,71 @@ extension DriveAnalyzer {
             }
 
             if let linkCap = IORegistryEntryCreateCFProperty(
-                parent, "IOPCIExpressLinkCapabilities" as CFString, kCFAllocatorDefault, 0
+                currentService, "IOPCIExpressLinkCapabilities" as CFString, kCFAllocatorDefault, 0
             ) {
                 if let cap = linkCap.takeRetainedValue() as? Int {
                     ApplicationLogger.shared.debug("Found PCIe Link Capabilities: \(cap)", category: .hardware)
                     let maxSpeed = cap & 0xF
                     if maxSpeed >= 5 {
                         ApplicationLogger.shared.debug("PCIe Gen 5+ detected - likely TB5", category: .hardware)
-                        IOObjectRelease(currentService)
-                        return .thunderbolt5
+                        result = .thunderbolt5
+                        break
                     }
                 }
             }
 
             if let linkSpeed = IORegistryEntryCreateCFProperty(
-                parent, "Link Speed" as CFString, kCFAllocatorDefault, 0
+                currentService, "Link Speed" as CFString, kCFAllocatorDefault, 0
             ) {
                 ApplicationLogger.shared.debug("Found Link Speed in TB detection: \(linkSpeed)", category: .hardware)
                 if let speed = linkSpeed.takeRetainedValue() as? Int {
                     if speed >= 80000 {
                         ApplicationLogger.shared.debug("Detected Thunderbolt 5 (80+ Gbps)", category: .hardware)
-                        IOObjectRelease(currentService)
-                        return .thunderbolt5
+                        result = .thunderbolt5
+                        break
                     } else if speed >= 40000 {
                         ApplicationLogger.shared.debug("Detected Thunderbolt 4 (40 Gbps)", category: .hardware)
-                        IOObjectRelease(currentService)
-                        return .thunderbolt4
+                        result = .thunderbolt4
+                        break
                     }
                 }
             }
 
             if let negotiatedSpeed = IORegistryEntryCreateCFProperty(
-                parent, "Negotiated Link Speed" as CFString, kCFAllocatorDefault, 0
+                currentService, "Negotiated Link Speed" as CFString, kCFAllocatorDefault, 0
             ) {
                 ApplicationLogger.shared.debug("Found Negotiated Link Speed: \(negotiatedSpeed)", category: .hardware)
                 if let speed = negotiatedSpeed.takeRetainedValue() as? Int {
                     if speed >= 80000 {
-                        IOObjectRelease(currentService)
-                        return .thunderbolt5
+                        result = .thunderbolt5
+                        break
                     } else if speed >= 40000 {
-                        IOObjectRelease(currentService)
-                        return .thunderbolt4
+                        result = .thunderbolt4
+                        break
                     }
                 }
             }
 
             if let tbGen = IORegistryEntryCreateCFProperty(
-                parent, "Thunderbolt Generation" as CFString, kCFAllocatorDefault, 0
+                currentService, "Thunderbolt Generation" as CFString, kCFAllocatorDefault, 0
             ) {
                 if let gen = tbGen.takeRetainedValue() as? Int {
                     ApplicationLogger.shared.debug("Found Thunderbolt Generation: \(gen)", category: .hardware)
-                    IOObjectRelease(currentService)
                     switch gen {
-                    case 5: return .thunderbolt5
-                    case 4: return .thunderbolt4
-                    default: return .thunderbolt3
+                    case 5: result = .thunderbolt5
+                    case 4: result = .thunderbolt4
+                    default: result = .thunderbolt3
                     }
+                    break
                 }
             }
         }
 
         IOObjectRelease(currentService)
+
+        if let result = result {
+            return result
+        }
 
         if foundJHL9580 {
             ApplicationLogger.shared.debug("Detected TB5 based on JHL9580 controller", category: .hardware)
@@ -314,7 +330,9 @@ extension DriveAnalyzer {
         guard result == KERN_SUCCESS else { return false }
         defer { IOObjectRelease(iterator) }
 
-        if IOIteratorNext(iterator) != 0 {
+        let service = IOIteratorNext(iterator)
+        if service != 0 {
+            IOObjectRelease(service)
             ApplicationLogger.shared.debug("Found IOThunderboltSwitchIntelJHL9580 (TB5) in system", category: .hardware)
             return true
         }
@@ -326,7 +344,9 @@ extension DriveAnalyzer {
         guard result2 == KERN_SUCCESS else { return false }
         defer { IOObjectRelease(iterator2) }
 
-        if IOIteratorNext(iterator2) != 0 {
+        let service2 = IOIteratorNext(iterator2)
+        if service2 != 0 {
+            IOObjectRelease(service2)
             ApplicationLogger.shared.debug("Found IOThunderboltSwitchIntelJHL9480 (TB5) in system", category: .hardware)
             return true
         }

--- a/ImageIntact/Models/DriveAnalyzerIOKit.swift
+++ b/ImageIntact/Models/DriveAnalyzerIOKit.swift
@@ -1,0 +1,372 @@
+import DiskArbitration
+import Foundation
+import IOKit
+import IOKit.storage
+import IOKit.usb
+
+// MARK: - IOKit and DiskArbitration queries (extracted for file-size limit)
+
+extension DriveAnalyzer {
+
+    static func isNetworkVolume(url: URL) -> Bool {
+        do {
+            let resourceValues = try url.resourceValues(forKeys: [.volumeIsLocalKey])
+            if let isLocal = resourceValues.volumeIsLocal {
+                return !isLocal
+            }
+        } catch {
+            ApplicationLogger.shared.debug("Error checking if volume is network: \(error)", category: .hardware)
+        }
+        return false
+    }
+
+    static func getBSDName(for url: URL) -> String? {
+        guard let session = DASessionCreate(kCFAllocatorDefault) else {
+            ApplicationLogger.shared.debug("Failed to create DA session", category: .hardware)
+            return nil
+        }
+
+        guard let disk = DADiskCreateFromVolumePath(kCFAllocatorDefault, session, url as CFURL) else {
+            ApplicationLogger.shared.debug("Failed to create disk from path: \(url.path)", category: .hardware)
+
+            if url.path.hasPrefix("/System") || url.path.hasPrefix("/Users") || url.path == "/" {
+                ApplicationLogger.shared.debug("Detected system path, using fallback", category: .hardware)
+                return getSystemVolumeBSDName()
+            }
+            return nil
+        }
+
+        guard let diskInfo = DADiskCopyDescription(disk) as? [String: Any] else {
+            ApplicationLogger.shared.debug("Failed to get disk description", category: .hardware)
+            return nil
+        }
+
+        ApplicationLogger.shared.debug("Disk info: \(diskInfo)", category: .hardware)
+
+        if let bsdName = diskInfo["DAMediaBSDName"] as? String {
+            ApplicationLogger.shared.debug("Found BSD name: \(bsdName)", category: .hardware)
+            return bsdName
+        } else if let volumePath = diskInfo["DAVolumePath"] as? URL {
+            ApplicationLogger.shared.debug("Volume path: \(volumePath)", category: .hardware)
+            if volumePath.path == "/" || url.path.hasPrefix(volumePath.path) {
+                return getSystemVolumeBSDName()
+            }
+        }
+
+        return nil
+    }
+
+    static func getSystemVolumeBSDName() -> String? {
+        var statInfo = statfs()
+        if statfs("/", &statInfo) == 0 {
+            let device = withUnsafePointer(to: &statInfo.f_mntfromname) { ptr in
+                ptr.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) { cString in
+                    String(cString: cString)
+                }
+            }
+            ApplicationLogger.shared.debug("System volume device from statfs: \(device)", category: .hardware)
+
+            if device.hasPrefix("/dev/") {
+                let bsdName = String(device.dropFirst(5))
+                if let baseRange = bsdName.range(of: "s[0-9]+$", options: .regularExpression) {
+                    return String(bsdName[..<baseRange.lowerBound])
+                }
+                return bsdName
+            }
+        }
+
+        ApplicationLogger.shared.debug("Using fallback BSD name for system volume", category: .hardware)
+        return "disk0"
+    }
+
+    // MARK: - Connection Type Detection
+
+    static func findConnectionType(for service: io_object_t) -> ConnectionType {
+        var parent: io_object_t = 0
+        var foundPCI = false
+        var foundThunderbolt = false
+
+        var currentService = service
+        IOObjectRetain(currentService)
+
+        while IORegistryEntryGetParentEntry(currentService, kIOServicePlane, &parent) == KERN_SUCCESS {
+            defer {
+                IOObjectRelease(currentService)
+                currentService = parent
+            }
+
+            var className = [CChar](repeating: 0, count: 128)
+            IOObjectGetClass(parent, &className)
+            let classString = String(cString: className)
+
+            ApplicationLogger.shared.debug("Checking class: \(classString)", category: .hardware)
+
+            if classString.contains("Thunderbolt") || classString.contains("Thunder") {
+                foundThunderbolt = true
+                ApplicationLogger.shared.debug("Found Thunderbolt in class name", category: .hardware)
+            }
+
+            if let protocolChar = IORegistryEntryCreateCFProperty(
+                parent, "Protocol Characteristics" as CFString, kCFAllocatorDefault, 0
+            ) {
+                if let dict = protocolChar.takeRetainedValue() as? [String: Any] {
+                    ApplicationLogger.shared.debug("Protocol Characteristics: \(dict)", category: .hardware)
+
+                    if let physical = dict["Physical Interconnect"] as? String {
+                        ApplicationLogger.shared.debug("Physical Interconnect: \(physical)", category: .hardware)
+
+                        if let location = dict["Physical Interconnect Location"] as? String {
+                            ApplicationLogger.shared.debug("Physical Location: \(location)", category: .hardware)
+                            if location == "External" && physical.contains("PCI") {
+                                ApplicationLogger.shared.debug("External PCI-Express detected - this IS Thunderbolt", category: .hardware)
+                                return detectThunderboltVersion(for: parent)
+                            }
+                        }
+
+                        if physical.contains("Thunderbolt") || physical.contains("Thunder") {
+                            ApplicationLogger.shared.debug("Detected Thunderbolt via Protocol Characteristics", category: .hardware)
+                            return .thunderbolt3
+                        } else if physical.contains("USB") {
+                            ApplicationLogger.shared.debug("Detected USB via Protocol Characteristics", category: .hardware)
+                            return detectUSBSpeed(for: parent)
+                        } else if physical.contains("PCI") {
+                            if let location = dict["Physical Interconnect Location"] as? String,
+                               location == "Internal"
+                            {
+                                ApplicationLogger.shared.debug("Internal PCI-Express - Internal drive", category: .hardware)
+                                return .internalDrive
+                            }
+                            foundPCI = true
+                        } else if physical.contains("SATA") {
+                            ApplicationLogger.shared.debug("Detected SATA - Internal drive", category: .hardware)
+                            return .internalDrive
+                        }
+                    }
+                }
+            }
+
+            if let deviceType = IORegistryEntryCreateCFProperty(
+                parent, "Device Type" as CFString, kCFAllocatorDefault, 0
+            ) {
+                if let typeString = deviceType.takeRetainedValue() as? String {
+                    ApplicationLogger.shared.debug("Device Type: \(typeString)", category: .hardware)
+                }
+            }
+
+            if let tbSpeed = IORegistryEntryCreateCFProperty(
+                parent, "Thunderbolt Speed" as CFString, kCFAllocatorDefault, 0
+            ) {
+                ApplicationLogger.shared.debug("Found Thunderbolt Speed property: \(tbSpeed)", category: .hardware)
+                foundThunderbolt = true
+            }
+
+            if let linkSpeed = IORegistryEntryCreateCFProperty(
+                parent, "Link Speed" as CFString, kCFAllocatorDefault, 0
+            ) {
+                ApplicationLogger.shared.debug("Found Link Speed: \(linkSpeed)", category: .hardware)
+                if let speed = linkSpeed.takeRetainedValue() as? Int {
+                    if speed >= 80000 {
+                        ApplicationLogger.shared.debug("Detected Thunderbolt 5 (80+ Gbps)", category: .hardware)
+                        return .thunderbolt5
+                    } else if speed >= 40000 {
+                        ApplicationLogger.shared.debug("Detected Thunderbolt 4 (40 Gbps)", category: .hardware)
+                        return .thunderbolt4
+                    } else if speed >= 20000 {
+                        foundThunderbolt = true
+                    }
+                }
+            }
+
+            if classString.contains("USB") {
+                ApplicationLogger.shared.debug("Detected USB via class name", category: .hardware)
+                return detectUSBSpeed(for: parent)
+            }
+
+            if classString.contains("NVMe") {
+                if foundThunderbolt {
+                    ApplicationLogger.shared.debug("NVMe over Thunderbolt", category: .hardware)
+                    return .thunderbolt3
+                }
+            }
+        }
+
+        IOObjectRelease(currentService)
+
+        if foundThunderbolt {
+            ApplicationLogger.shared.debug("Final decision: Thunderbolt", category: .hardware)
+            return .thunderbolt3
+        } else if foundPCI {
+            ApplicationLogger.shared.debug("Final decision: Unknown (PCI but unclear if external)", category: .hardware)
+            return .unknown
+        }
+
+        ApplicationLogger.shared.debug("Final decision: Unknown", category: .hardware)
+        return .unknown
+    }
+
+    // MARK: - Thunderbolt Version Detection
+
+    static func detectThunderboltVersion(for service: io_object_t) -> ConnectionType {
+        if isThunderbolt5SystemPresent() {
+            ApplicationLogger.shared.debug("TB5 controller detected in system, assuming TB5 for external PCI-Express", category: .hardware)
+            return .thunderbolt5
+        }
+
+        var parent: io_object_t = 0
+        var currentService = service
+        IOObjectRetain(currentService)
+
+        var foundJHL9580 = false
+
+        while IORegistryEntryGetParentEntry(currentService, kIOServicePlane, &parent) == KERN_SUCCESS {
+            defer {
+                IOObjectRelease(currentService)
+                currentService = parent
+            }
+
+            var className = [CChar](repeating: 0, count: 128)
+            IOObjectGetClass(parent, &className)
+            let classString = String(cString: className)
+
+            if classString.contains("JHL9580") || classString.contains("JHL9480") {
+                ApplicationLogger.shared.debug("Found TB5 controller (JHL9580/9480)", category: .hardware)
+                foundJHL9580 = true
+            }
+
+            if let linkCap = IORegistryEntryCreateCFProperty(
+                parent, "IOPCIExpressLinkCapabilities" as CFString, kCFAllocatorDefault, 0
+            ) {
+                if let cap = linkCap.takeRetainedValue() as? Int {
+                    ApplicationLogger.shared.debug("Found PCIe Link Capabilities: \(cap)", category: .hardware)
+                    let maxSpeed = cap & 0xF
+                    if maxSpeed >= 5 {
+                        ApplicationLogger.shared.debug("PCIe Gen 5+ detected - likely TB5", category: .hardware)
+                        IOObjectRelease(currentService)
+                        return .thunderbolt5
+                    }
+                }
+            }
+
+            if let linkSpeed = IORegistryEntryCreateCFProperty(
+                parent, "Link Speed" as CFString, kCFAllocatorDefault, 0
+            ) {
+                ApplicationLogger.shared.debug("Found Link Speed in TB detection: \(linkSpeed)", category: .hardware)
+                if let speed = linkSpeed.takeRetainedValue() as? Int {
+                    if speed >= 80000 {
+                        ApplicationLogger.shared.debug("Detected Thunderbolt 5 (80+ Gbps)", category: .hardware)
+                        IOObjectRelease(currentService)
+                        return .thunderbolt5
+                    } else if speed >= 40000 {
+                        ApplicationLogger.shared.debug("Detected Thunderbolt 4 (40 Gbps)", category: .hardware)
+                        IOObjectRelease(currentService)
+                        return .thunderbolt4
+                    }
+                }
+            }
+
+            if let negotiatedSpeed = IORegistryEntryCreateCFProperty(
+                parent, "Negotiated Link Speed" as CFString, kCFAllocatorDefault, 0
+            ) {
+                ApplicationLogger.shared.debug("Found Negotiated Link Speed: \(negotiatedSpeed)", category: .hardware)
+                if let speed = negotiatedSpeed.takeRetainedValue() as? Int {
+                    if speed >= 80000 {
+                        IOObjectRelease(currentService)
+                        return .thunderbolt5
+                    } else if speed >= 40000 {
+                        IOObjectRelease(currentService)
+                        return .thunderbolt4
+                    }
+                }
+            }
+
+            if let tbGen = IORegistryEntryCreateCFProperty(
+                parent, "Thunderbolt Generation" as CFString, kCFAllocatorDefault, 0
+            ) {
+                if let gen = tbGen.takeRetainedValue() as? Int {
+                    ApplicationLogger.shared.debug("Found Thunderbolt Generation: \(gen)", category: .hardware)
+                    IOObjectRelease(currentService)
+                    switch gen {
+                    case 5: return .thunderbolt5
+                    case 4: return .thunderbolt4
+                    default: return .thunderbolt3
+                    }
+                }
+            }
+        }
+
+        IOObjectRelease(currentService)
+
+        if foundJHL9580 {
+            ApplicationLogger.shared.debug("Detected TB5 based on JHL9580 controller", category: .hardware)
+            return .thunderbolt5
+        }
+
+        ApplicationLogger.shared.debug("Defaulting to Thunderbolt 3", category: .hardware)
+        return .thunderbolt3
+    }
+
+    static func isThunderbolt5SystemPresent() -> Bool {
+        var iterator: io_iterator_t = 0
+
+        let matching = IOServiceMatching("IOThunderboltSwitchIntelJHL9580")
+        let result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator)
+
+        guard result == KERN_SUCCESS else { return false }
+        defer { IOObjectRelease(iterator) }
+
+        if IOIteratorNext(iterator) != 0 {
+            ApplicationLogger.shared.debug("Found IOThunderboltSwitchIntelJHL9580 (TB5) in system", category: .hardware)
+            return true
+        }
+
+        let matching2 = IOServiceMatching("IOThunderboltSwitchIntelJHL9480")
+        var iterator2: io_iterator_t = 0
+        let result2 = IOServiceGetMatchingServices(kIOMainPortDefault, matching2, &iterator2)
+
+        guard result2 == KERN_SUCCESS else { return false }
+        defer { IOObjectRelease(iterator2) }
+
+        if IOIteratorNext(iterator2) != 0 {
+            ApplicationLogger.shared.debug("Found IOThunderboltSwitchIntelJHL9480 (TB5) in system", category: .hardware)
+            return true
+        }
+
+        return false
+    }
+
+    // MARK: - USB Speed Detection
+
+    static func detectUSBSpeed(for service: io_object_t) -> ConnectionType {
+        if let speedProp = IORegistryEntryCreateCFProperty(
+            service, "USB Speed" as CFString, kCFAllocatorDefault, 0
+        ) {
+            if let speed = speedProp.takeRetainedValue() as? Int {
+                switch speed {
+                case 0 ... 1: return .usb2
+                case 2: return .usb2
+                case 3: return .usb30
+                case 4: return .usb31Gen2
+                case 5: return .usb32Gen2x2
+                default: return .usb30
+                }
+            }
+        }
+
+        if let deviceSpeedProp = IORegistryEntryCreateCFProperty(
+            service, "Device Speed" as CFString, kCFAllocatorDefault, 0
+        ) {
+            if let speed = deviceSpeedProp.takeRetainedValue() as? Int {
+                switch speed {
+                case 0: return .usb2
+                case 1: return .usb2
+                case 2: return .usb2
+                case 3: return .usb30
+                case 4: return .usb31Gen2
+                default: return .usb30
+                }
+            }
+        }
+
+        return .usb30
+    }
+}

--- a/ImageIntact/Models/DriveInfoCache.swift
+++ b/ImageIntact/Models/DriveInfoCache.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Thread-safe cache for DriveInfo results keyed by volume UUID.
+/// Eliminates redundant IOKit queries when the same drive is analyzed
+/// by multiple callers (DriveMonitor, DestinationManager, callbacks).
+final class DriveInfoCache {
+    private var entries: [String: DriveAnalyzer.DriveInfo] = [:]
+    private let lock = NSLock()
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries.count
+    }
+
+    func get(volumeUUID: String) -> DriveAnalyzer.DriveInfo? {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries[volumeUUID]
+    }
+
+    func store(_ info: DriveAnalyzer.DriveInfo) {
+        guard let uuid = info.volumeUUID else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        entries[uuid] = info
+    }
+
+    func invalidate(volumeUUID: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.removeValue(forKey: volumeUUID)
+    }
+
+    func invalidateAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.removeAll()
+    }
+}

--- a/ImageIntact/Models/DriveMonitor.swift
+++ b/ImageIntact/Models/DriveMonitor.swift
@@ -388,6 +388,10 @@ private func driveDisappearedCallback(disk: DADisk?, context: UnsafeMutableRawPo
       monitor.recentlyDisconnected.append(driveInfo)
       monitor.driveDisconnected.send(driveInfo)
 
+      if let uuid = driveInfo.volumeUUID {
+        DriveAnalyzer.cache.invalidate(volumeUUID: uuid)
+      }
+
       logInfo("Drive disconnected: \(driveInfo.deviceName)")
 
       // Keep only last 5 disconnected drives

--- a/ImageIntactTests/DriveAnalyzerTests.swift
+++ b/ImageIntactTests/DriveAnalyzerTests.swift
@@ -275,6 +275,20 @@ final class DriveAnalyzerTests: XCTestCase {
         XCTAssertEqual(cache.count, 1)
     }
 
+    // MARK: - Fresh Volume Attributes
+
+    func testWithFreshVolumeAttributes_updatesCapacityAndFreeSpace() {
+        let original = makeDriveInfo(connectionType: .thunderbolt4, isSSD: true, volumeUUID: "UUID-1")
+        let newURL = URL(fileURLWithPath: "/Volumes/Renamed")
+        let refreshed = original.withFreshVolumeAttributes(url: newURL, totalCapacity: 2_000_000_000_000, freeSpace: 100_000_000_000)
+
+        XCTAssertEqual(refreshed.totalCapacity, 2_000_000_000_000)
+        XCTAssertEqual(refreshed.freeSpace, 100_000_000_000)
+        XCTAssertEqual(refreshed.mountPath, newURL)
+        XCTAssertEqual(refreshed.connectionType, .thunderbolt4)
+        XCTAssertEqual(refreshed.deviceName, "Test Drive")
+    }
+
     // MARK: - Helpers
 
     private func makeDriveInfo(

--- a/ImageIntactTests/DriveAnalyzerTests.swift
+++ b/ImageIntactTests/DriveAnalyzerTests.swift
@@ -1,0 +1,301 @@
+//
+//  DriveAnalyzerTests.swift
+//  ImageIntactTests
+//
+//  Tests for DriveAnalyzer: drive type detection, time estimation, cache behavior
+//
+
+import XCTest
+@testable import ImageIntact
+
+final class DriveAnalyzerTests: XCTestCase {
+
+    // MARK: - Drive Type Detection
+
+    func testDetectDriveType_cameraInName_returnsInCamera() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "Canon EOS R5",
+            deviceModel: nil,
+            connectionType: .usb30,
+            isSSD: false,
+            capacity: 64_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .inCamera)
+    }
+
+    func testDetectDriveType_hasselblad_returnsInCamera() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "Hasselblad X2D",
+            deviceModel: nil,
+            connectionType: .usb30,
+            isSSD: false,
+            capacity: 64_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .inCamera)
+    }
+
+    func testDetectDriveType_sdCard_returnsCameraCard() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "SDXC Card",
+            deviceModel: nil,
+            connectionType: .usb30,
+            isSSD: false,
+            capacity: 128_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .cameraCard)
+    }
+
+    func testDetectDriveType_cardReader_returnsCardReader() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "USB Card Reader",
+            deviceModel: nil,
+            connectionType: .usb30,
+            isSSD: false,
+            capacity: 64_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .cardReader)
+    }
+
+    func testDetectDriveType_samsungT7_returnsPortableSSD() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "Samsung T7",
+            deviceModel: nil,
+            connectionType: .usb31Gen2,
+            isSSD: true,
+            capacity: 1_000_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .portableSSD)
+    }
+
+    func testDetectDriveType_thunderboltSSD_returnsPortableSSD() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "External Drive",
+            deviceModel: nil,
+            connectionType: .thunderbolt4,
+            isSSD: true,
+            capacity: 2_000_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .portableSSD)
+    }
+
+    func testDetectDriveType_internalDrive_returnsInternal() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "APPLE SSD",
+            deviceModel: nil,
+            connectionType: .internalDrive,
+            isSSD: true,
+            capacity: 1_000_000_000_000,
+            bsdName: "disk0"
+        )
+        XCTAssertEqual(result, .internalDrive)
+    }
+
+    func testDetectDriveType_networkDrive_returnsNetwork() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "NAS Share",
+            deviceModel: nil,
+            connectionType: .network,
+            isSSD: false,
+            capacity: 10_000_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .networkDrive)
+    }
+
+    func testDetectDriveType_usbHDD_returnsExternalHDD() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "WD Elements",
+            deviceModel: nil,
+            connectionType: .usb30,
+            isSSD: false,
+            capacity: 4_000_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .externalHDD)
+    }
+
+    func testDetectDriveType_cfexpress_returnsCameraCard() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "CFexpress Card",
+            deviceModel: nil,
+            connectionType: .usb31Gen2,
+            isSSD: true,
+            capacity: 256_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .cameraCard)
+    }
+
+    func testDetectDriveType_sandiskModel_returnsCameraCard() {
+        let result = DriveAnalyzer.detectDriveType(
+            deviceName: "External",
+            deviceModel: "SanDisk Extreme Pro 128GB",
+            connectionType: .usb30,
+            isSSD: true,
+            capacity: 128_000_000_000,
+            bsdName: "disk2"
+        )
+        XCTAssertEqual(result, .cameraCard)
+    }
+
+    // MARK: - Backup Time Estimation
+
+    func testEstimateBackupTime_thunderbolt4_1GB() {
+        let info = makeDriveInfo(connectionType: .thunderbolt4, isSSD: true)
+        let time = info.estimateBackupTime(totalBytes: 1_000_000_000)
+        // 1 GB at ~500 MB/s * 0.95 = ~475 MB/s copy + 35% verify
+        // Copy: 1000/475 = ~2.1s, Verify: ~0.7s, Total: ~2.8s
+        XCTAssertGreaterThan(time, 1.0)
+        XCTAssertLessThan(time, 10.0)
+    }
+
+    func testEstimateBackupTime_usb2_10GB() {
+        let info = makeDriveInfo(connectionType: .usb2, isSSD: false)
+        let time = info.estimateBackupTime(totalBytes: 10_000_000_000)
+        // 10 GB at ~20 MB/s = ~500s copy + verify
+        XCTAssertGreaterThan(time, 400.0)
+        XCTAssertLessThan(time, 1000.0)
+    }
+
+    func testEstimateBackupTime_zeroBytes() {
+        let info = makeDriveInfo(connectionType: .thunderbolt4, isSSD: true)
+        let time = info.estimateBackupTime(totalBytes: 0)
+        XCTAssertEqual(time, 0.0, accuracy: 0.001)
+    }
+
+    // MARK: - Formatted Estimate
+
+    func testFormattedEstimate_underOneMinute() {
+        let info = makeDriveInfo(connectionType: .thunderbolt4, isSSD: true)
+        let formatted = info.formattedEstimate(totalBytes: 100_000_000) // 100 MB
+        XCTAssertEqual(formatted, "< 1 minute")
+    }
+
+    func testFormattedEstimate_minutes() {
+        let info = makeDriveInfo(connectionType: .usb2, isSSD: false)
+        let formatted = info.formattedEstimate(totalBytes: 5_000_000_000) // 5 GB over USB 2
+        XCTAssertTrue(formatted.contains("minute"))
+    }
+
+    func testFormattedEstimate_hours() {
+        let info = makeDriveInfo(connectionType: .usb2, isSSD: false)
+        let formatted = info.formattedEstimate(totalBytes: 500_000_000_000) // 500 GB over USB 2
+        XCTAssertTrue(formatted.contains("hour"))
+    }
+
+    // MARK: - Connection Type Properties
+
+    func testConnectionType_writeSpeedOrdering() {
+        let types: [ConnectionType] = [.usb2, .usb30, .usb31Gen1, .usb31Gen2, .thunderbolt3, .thunderbolt4, .thunderbolt5]
+        for i in 0..<(types.count - 1) {
+            XCTAssertLessThan(
+                types[i].estimatedWriteSpeedMBps,
+                types[i + 1].estimatedWriteSpeedMBps,
+                "\(types[i].displayName) should be slower than \(types[i + 1].displayName)"
+            )
+        }
+    }
+
+    func testConnectionType_readFasterThanWrite() {
+        let types: [ConnectionType] = [.usb30, .thunderbolt4, .internalDrive, .network]
+        for type in types {
+            XCTAssertGreaterThan(
+                type.estimatedReadSpeedMBps,
+                type.estimatedWriteSpeedMBps,
+                "\(type.displayName) read should be faster than write"
+            )
+        }
+    }
+
+    // MARK: - DriveInfo Cache
+
+    func testDriveInfoCache_hitOnSameUUID() {
+        let cache = DriveInfoCache()
+        let info = makeDriveInfo(connectionType: .thunderbolt4, isSSD: true, volumeUUID: "UUID-123")
+        cache.store(info)
+
+        let cached = cache.get(volumeUUID: "UUID-123")
+        XCTAssertNotNil(cached)
+        XCTAssertEqual(cached?.connectionType, .thunderbolt4)
+    }
+
+    func testDriveInfoCache_missOnDifferentUUID() {
+        let cache = DriveInfoCache()
+        let info = makeDriveInfo(connectionType: .thunderbolt4, isSSD: true, volumeUUID: "UUID-123")
+        cache.store(info)
+
+        let cached = cache.get(volumeUUID: "UUID-999")
+        XCTAssertNil(cached)
+    }
+
+    func testDriveInfoCache_invalidateByUUID() {
+        let cache = DriveInfoCache()
+        let info = makeDriveInfo(connectionType: .thunderbolt4, isSSD: true, volumeUUID: "UUID-123")
+        cache.store(info)
+
+        cache.invalidate(volumeUUID: "UUID-123")
+
+        let cached = cache.get(volumeUUID: "UUID-123")
+        XCTAssertNil(cached)
+    }
+
+    func testDriveInfoCache_invalidateAll() {
+        let cache = DriveInfoCache()
+        cache.store(makeDriveInfo(connectionType: .thunderbolt4, isSSD: true, volumeUUID: "UUID-1"))
+        cache.store(makeDriveInfo(connectionType: .usb30, isSSD: false, volumeUUID: "UUID-2"))
+
+        cache.invalidateAll()
+
+        XCTAssertNil(cache.get(volumeUUID: "UUID-1"))
+        XCTAssertNil(cache.get(volumeUUID: "UUID-2"))
+    }
+
+    func testDriveInfoCache_nilUUID_notCached() {
+        let cache = DriveInfoCache()
+        let info = makeDriveInfo(connectionType: .thunderbolt4, isSSD: true, volumeUUID: nil)
+        cache.store(info)
+
+        // Can't retrieve without a UUID
+        XCTAssertEqual(cache.count, 0)
+    }
+
+    func testDriveInfoCache_updateExisting() {
+        let cache = DriveInfoCache()
+        cache.store(makeDriveInfo(connectionType: .usb30, isSSD: false, volumeUUID: "UUID-1"))
+        cache.store(makeDriveInfo(connectionType: .thunderbolt4, isSSD: true, volumeUUID: "UUID-1"))
+
+        let cached = cache.get(volumeUUID: "UUID-1")
+        XCTAssertEqual(cached?.connectionType, .thunderbolt4)
+        XCTAssertEqual(cache.count, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeDriveInfo(
+        connectionType: ConnectionType,
+        isSSD: Bool,
+        volumeUUID: String? = "TEST-UUID"
+    ) -> DriveInfo {
+        DriveInfo(
+            mountPath: URL(fileURLWithPath: "/Volumes/TestDrive"),
+            connectionType: connectionType,
+            isSSD: isSSD,
+            deviceName: "Test Drive",
+            protocolDetails: connectionType.displayName,
+            estimatedWriteSpeed: connectionType.estimatedWriteSpeedMBps,
+            estimatedReadSpeed: connectionType.estimatedReadSpeedMBps,
+            volumeUUID: volumeUUID,
+            hardwareSerial: "SERIAL-123",
+            deviceModel: "Test Model",
+            totalCapacity: 1_000_000_000_000,
+            freeSpace: 500_000_000_000,
+            driveType: isSSD ? .portableSSD : .externalHDD
+        )
+    }
+}

--- a/ImageIntactTests/DriveMonitorTests.swift
+++ b/ImageIntactTests/DriveMonitorTests.swift
@@ -1,0 +1,99 @@
+//
+//  DriveMonitorTests.swift
+//  ImageIntactTests
+//
+//  Tests for DriveMonitor using MockDriveAnalyzer
+//
+
+import Combine
+import XCTest
+@testable import ImageIntact
+
+final class DriveMonitorTests: XCTestCase {
+
+    var monitor: DriveMonitor!
+    var mockAnalyzer: MockDriveAnalyzer!
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        mockAnalyzer = MockDriveAnalyzer()
+        monitor = DriveMonitor.shared
+        monitor.driveAnalyzer = mockAnalyzer
+        cancellables = []
+    }
+
+    override func tearDown() {
+        monitor.driveAnalyzer = RealDriveAnalyzer()
+        cancellables = nil
+        super.tearDown()
+    }
+
+    // MARK: - Mock Analyzer Usage
+
+    func testGetDriveDetails_usesMockAnalyzer() {
+        let url = URL(fileURLWithPath: "/Volumes/TestSSD")
+        mockAnalyzer.addMockDrive(
+            at: url,
+            connectionType: .thunderbolt4,
+            isSSD: true,
+            driveType: .portableSSD
+        )
+
+        let info = monitor.getDriveDetails(url)
+
+        XCTAssertNotNil(info)
+        XCTAssertEqual(info?.connectionType, .thunderbolt4)
+        XCTAssertEqual(info?.driveType, .portableSSD)
+        XCTAssertEqual(mockAnalyzer.analysisCallCount, 1)
+    }
+
+    func testGetDriveDetails_failingAnalyzer_returnsNil() {
+        mockAnalyzer.shouldFailAnalysis = true
+        let url = URL(fileURLWithPath: "/Volumes/TestSSD")
+
+        let info = monitor.getDriveDetails(url)
+
+        XCTAssertNil(info)
+        XCTAssertEqual(mockAnalyzer.analysisCallCount, 1)
+    }
+
+    func testGetDriveDetails_multipleCallsWithMock() {
+        let url1 = URL(fileURLWithPath: "/Volumes/SSD1")
+        let url2 = URL(fileURLWithPath: "/Volumes/SSD2")
+        mockAnalyzer.addMockDrive(at: url1, connectionType: .thunderbolt4, isSSD: true, driveType: .portableSSD)
+        mockAnalyzer.addMockDrive(at: url2, connectionType: .usb31Gen2, isSSD: true, driveType: .portableSSD)
+
+        let info1 = monitor.getDriveDetails(url1)
+        let info2 = monitor.getDriveDetails(url2)
+
+        XCTAssertEqual(info1?.connectionType, .thunderbolt4)
+        XCTAssertEqual(info2?.connectionType, .usb31Gen2)
+        XCTAssertEqual(mockAnalyzer.analysisCallCount, 2)
+    }
+
+    // MARK: - Drive Identity Management
+
+    func testSetCustomName_persistsName() {
+        let uuid = "TEST-UUID-12345"
+        // Manually insert a known drive for testing
+        monitor.setCustomName(for: uuid, name: "My Backup SSD")
+        // Getting the name back requires the drive to exist in knownDrives
+        // This tests the path doesn't crash - full persistence test would need file I/O
+    }
+
+    // MARK: - Mock Analyzer Reset
+
+    func testMockAnalyzer_resetClearsState() {
+        let url = URL(fileURLWithPath: "/Volumes/Test")
+        mockAnalyzer.addMockDrive(at: url, connectionType: .thunderbolt4, isSSD: true)
+        _ = mockAnalyzer.analyzeDrive(at: url)
+
+        XCTAssertEqual(mockAnalyzer.analysisCallCount, 1)
+
+        mockAnalyzer.reset()
+
+        XCTAssertEqual(mockAnalyzer.analysisCallCount, 0)
+        XCTAssertTrue(mockAnalyzer.mockDrives.isEmpty)
+    }
+}

--- a/ImageIntactTests/DriveMonitorTests.swift
+++ b/ImageIntactTests/DriveMonitorTests.swift
@@ -74,12 +74,8 @@ final class DriveMonitorTests: XCTestCase {
 
     // MARK: - Drive Identity Management
 
-    func testSetCustomName_persistsName() {
-        let uuid = "TEST-UUID-12345"
-        // Manually insert a known drive for testing
-        monitor.setCustomName(for: uuid, name: "My Backup SSD")
-        // Getting the name back requires the drive to exist in knownDrives
-        // This tests the path doesn't crash - full persistence test would need file I/O
+    func testSetCustomName_doesNotCrashForUnknownUUID() {
+        monitor.setCustomName(for: "NONEXISTENT-UUID", name: "My Backup SSD")
     }
 
     // MARK: - Mock Analyzer Reset


### PR DESCRIPTION
## Summary
- **Root cause:** `DriveAnalyzer.analyzeDrive()` did 4 separate `IOServiceGetMatchingServices("IOMedia")` full-registry scans per drive, each iterating every IOMedia object to find one BSD name. Two external SSDs = 8+ full registry walks, causing multi-second hangs at startup and when adding drives.
- **Fix:** Replaced with single `IOBSDNameMatching` direct lookup (O(1) instead of O(n)), gathering all properties in one pass via `gatherDriveProperties()`. Added UUID-keyed `DriveInfoCache` to eliminate redundant analysis across DriveMonitor, DestinationManager, and DiskArbitration callbacks.
- **Split:** Extracted IOKit query methods to `DriveAnalyzerIOKit.swift` to comply with 500-line limit. Net: -716 lines from main file, +3 new files.
- **Tests:** Added 30 unit tests (DriveAnalyzerTests + DriveMonitorTests) covering drive type detection, time estimation, cache hit/miss/invalidation, and mock analyzer integration.

## Test plan
- [x] 30 new unit tests pass (DriveAnalyzerTests: 25, DriveMonitorTests: 5)
- [x] Full test suite — no regressions (pre-existing failures in RetryCountTests, ManifestBuilderFilterTests, SubdirectoryTraversalTests are unchanged)
- [x] Build succeeds
- [ ] Manual: verify drive info matches before/after on real hardware with external SSDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)