### PR TITLE
refactor: GCD-bridge ManifestBuilder.calculateChecksum (#108)

### DIFF
--- a/ImageIntact/Models/ManifestBuilder.swift
+++ b/ImageIntact/Models/ManifestBuilder.swift
@@ -326,12 +326,27 @@ actor ManifestBuilder {
 
     // MARK: - Private Methods
 
-    /// Calculate SHA256 checksum for a file
+    /// Calculate SHA256 checksum for a file.
+    ///
+    /// Bridges the synchronous, blocking SHA-256 read into async via GCD.
+    /// `Task.detached` would *not* solve cooperative-pool starvation here — detached
+    /// tasks still run on the same pool, sized to active core count. GCD's global
+    /// queues spawn additional threads for blocking work, keeping the cooperative
+    /// pool free for other async tasks. Same pattern as the protocol-impl call sites
+    /// in `CancellableFileOperations` / `DefaultFileOperations` / `BatchFileProcessor`
+    /// (PR #107). See Apple WWDC 2021 — "Swift concurrency: Behind the scenes".
     private func calculateChecksum(for url: URL, shouldCancel: @escaping () -> Bool) async throws
         -> String
     {
-        try await Task.detached(priority: .userInitiated) {
-            try ChecksumService.sha256(for: url, shouldCancel: shouldCancel)
-        }.value
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let result = try ChecksumService.sha256(for: url, shouldCancel: shouldCancel)
+                    continuation.resume(returning: result)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Item 2 of 7 from #108 — completes the concurrency cleanup started in PR #107. `ManifestBuilder` was the lone remaining call site using `Task.detached` for the synchronous `ChecksumService.sha256` read.

Replaced with `withCheckedThrowingContinuation` + `DispatchQueue.global(qos: .userInitiated).async`. Same pattern as the three other call sites cleaned up in PR #107 (`CancellableFileOperations`, `DefaultFileOperations`, `BatchFileProcessor`). Inline comments at those three sites already tracked this as the outstanding follow-up.

## Why GCD over Task.detached

`Task.detached` only escapes the *actor's* serial executor — it still consumes a slot on the cooperative thread pool (sized to active core count). Concurrent blocking I/O on detached tasks can starve other async work. GCD's global queues spawn additional threads for blocking work, leaving the cooperative pool free. Reference: WWDC 2021 "Swift concurrency: Behind the scenes".

## Diff

19 insertions / 4 deletions, single file (`ImageIntact/Models/ManifestBuilder.swift`).

## Tests

`xcodebuild test -scheme ImageIntact -configuration Debug -destination 'platform=macOS,arch=arm64'` (signing disabled):

- **407 passed / 10 failed** — same 10 pre-existing failures (`ManifestBuilderFilterTests` × 7, `SubdirectoryTraversalTests` × 3) documented in the project memory. No new failures, no flake-band hit this run.

The existing checksum coverage (`NativeChecksumTests`, `ChecksumPerformanceTests`, `ChecksumCancellationTests`, `MemoryOptimizationTests`, `BatchFileProcessorTests`) exercises this path indirectly through manifest building paths.

## Test plan

- [x] `xcodebuild test` passes at the same baseline as `main`
- [x] Checksum regression suites all green