### PR TITLE
refactor: typed ChecksumServiceError + drop TOCTOU pre-checks (#108)

### DIFF
--- a/ImageIntact/Models/ChecksumService.swift
+++ b/ImageIntact/Models/ChecksumService.swift
@@ -3,23 +3,61 @@
 //  ImageIntact
 //
 //  Stateless checksum computation extracted from BackupManager (#103, AMUX-17).
-//  Wraps OptimizedChecksum.sha256 with iCloud-not-downloaded detection
-//  and readability checks, throwing on all failure paths.
+//  Wraps OptimizedChecksum.sha256 with iCloud-not-downloaded detection and
+//  typed error mapping. Pre-existing TOCTOU `fileExists`/`isReadableFile`
+//  pre-checks were dropped (#108 items 1+4): the underlying read either
+//  succeeds or throws a Cocoa error, which we map to a typed
+//  `ChecksumServiceError`. No logging — callers have job context and decide
+//  what to log (#108 items 5+6).
 //
 
 import Foundation
 
+/// Strongly-typed errors thrown by `ChecksumService`. Replaces the pre-existing
+/// `NSError(domain: "ImageIntact", code: 1/7, ...)` pattern from `BackupManager`.
+///
+/// The associated `URL` lets callers report which file failed without having to
+/// preserve it from the call site. `LocalizedError` conformance keeps existing
+/// `error.localizedDescription` consumers working.
+enum ChecksumServiceError: Error, LocalizedError, Equatable {
+    case fileNotFound(URL)
+    case iCloudNotDownloaded(URL)
+    case unreadable(URL)
+
+    var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let url):
+            return "File does not exist: \(url.lastPathComponent)"
+        case .iCloudNotDownloaded(let url):
+            return "File is in iCloud but not downloaded: \(url.lastPathComponent)"
+        case .unreadable(let url):
+            return "File is not readable: \(url.lastPathComponent)"
+        }
+    }
+}
+
 enum ChecksumService {
     /// SHA-256 checksum of `fileURL` using the project's optimized native implementation.
     ///
-    /// Behavior:
-    /// - Throws `NSError` (domain `"ImageIntact"`, code `1`) if the file does not exist.
-    /// - Throws `NSError` (domain `"ImageIntact"`, code `7`) if the file is in iCloud and not yet downloaded.
-    /// - Throws `NSError` (domain `"ImageIntact"`, code `1`) if the file is unreadable.
-    /// - Rethrows `ChecksumError` (including `.cancelled`), `CancellationError`, and any
-    ///   underlying read failure. The previous size-based fallback was removed — for a
-    ///   verification tool, masking a read failure with `"size:%016x"` is a data-integrity
-    ///   risk (two different files with the same byte size produce the same fake checksum).
+    /// Throws:
+    /// - `ChecksumServiceError.iCloudNotDownloaded(url)` — file is in iCloud but not yet
+    ///   downloaded locally. Detected up front via `ubiquitousItemDownloadingStatus`
+    ///   resource value (semantic check, not TOCTOU; the underlying read would either
+    ///   silently trigger a download or fail with a confusing native error).
+    /// - `ChecksumServiceError.fileNotFound(url)` — mapped from
+    ///   `NSCocoaErrorDomain` + `NSFileReadNoSuchFileError` raised by the read.
+    /// - `ChecksumServiceError.unreadable(url)` — mapped from
+    ///   `NSCocoaErrorDomain` + `NSFileReadNoPermissionError` raised by the read.
+    /// - `ChecksumError.cancelled` — propagated from `OptimizedChecksum` when the
+    ///   `shouldCancel` closure returns true, or when a `CancellationError` is caught
+    ///   from the surrounding `Task`.
+    /// - Any other `NSError` from the read is rethrown as-is (e.g., I/O errors,
+    ///   filesystem corruption).
+    ///
+    /// The previous size-based fallback (`"size:%016x"`) was removed in PR #107 —
+    /// for a verification tool, masking a read failure with a fake hash is a
+    /// data-integrity risk (two different files of the same byte size produce the
+    /// same fake checksum).
     ///
     /// - Parameters:
     ///   - fileURL: file to hash
@@ -27,46 +65,20 @@ enum ChecksumService {
     static func sha256(
         for fileURL: URL, shouldCancel: @Sendable @escaping () -> Bool
     ) throws -> String {
-        // First check if file exists
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            throw NSError(
-                domain: "ImageIntact", code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "File does not exist: \(fileURL.lastPathComponent)"]
-            )
+        // iCloud-not-downloaded check (semantic, not TOCTOU — the resource value isn't
+        // surfaced from a CryptoKit read in any reliable way).
+        if let status = try? fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
+            .ubiquitousItemDownloadingStatus,
+            status == .notDownloaded
+        {
+            throw ChecksumServiceError.iCloudNotDownloaded(fileURL)
         }
 
-        // Special handling for files that might be in iCloud and not downloaded
-        let resourceValues = try? fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
-        if let status = resourceValues?.ubiquitousItemDownloadingStatus {
-            // Status can be: .current, .downloaded, .notDownloaded
-            if status == .notDownloaded {
-                ApplicationLogger.shared.warning(
-                    "File is in iCloud but not downloaded locally: \(fileURL.lastPathComponent)",
-                    category: .app
-                )
-                throw NSError(
-                    domain: "ImageIntact", code: 7,
-                    userInfo: [
-                        NSLocalizedDescriptionKey:
-                            "File is in iCloud but not downloaded: \(fileURL.lastPathComponent)",
-                    ]
-                )
-            }
-        }
-
-        // Check if file is readable
-        guard FileManager.default.isReadableFile(atPath: fileURL.path) else {
-            throw NSError(
-                domain: "ImageIntact", code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "File is not readable: \(fileURL.lastPathComponent)"]
-            )
-        }
-
-        // Use native Swift checksum as primary method for reliability
         return try calculateNative(for: fileURL, shouldCancel: shouldCancel)
     }
 
-    // Native Swift checksum using CryptoKit - delegates to the optimized implementation
+    /// Native Swift checksum via `OptimizedChecksum`. Maps Cocoa file errors to
+    /// `ChecksumServiceError`; rethrows cancellation as `ChecksumError.cancelled`.
     private static func calculateNative(
         for fileURL: URL, shouldCancel: @Sendable @escaping () -> Bool
     ) throws -> String {
@@ -78,10 +90,19 @@ enum ChecksumService {
         } catch is CancellationError {
             // Never swallow Swift Task cancellation either
             throw ChecksumError.cancelled
+        } catch let nsError as NSError where nsError.domain == NSCocoaErrorDomain {
+            switch nsError.code {
+            case NSFileReadNoSuchFileError, NSFileNoSuchFileError:
+                throw ChecksumServiceError.fileNotFound(fileURL)
+            case NSFileReadNoPermissionError:
+                throw ChecksumServiceError.unreadable(fileURL)
+            default:
+                throw nsError
+            }
         }
-        // All other read failures bubble up to the caller as-is. Returning a
-        // size-based pseudo-checksum here would silently treat distinct files as
-        // identical when reads fail under load — unacceptable for a backup tool.
+        // Any non-Cocoa error bubbles up to the caller as-is. Returning a size-based
+        // pseudo-checksum here would silently treat distinct files as identical when
+        // reads fail under load — unacceptable for a backup tool.
     }
 
     /// Async wrapper around `sha256(for:shouldCancel:)` that bridges the synchronous,

--- a/ImageIntact/Models/ChecksumService.swift
+++ b/ImageIntact/Models/ChecksumService.swift
@@ -19,10 +19,22 @@ import Foundation
 /// The associated `URL` lets callers report which file failed without having to
 /// preserve it from the call site. `LocalizedError` conformance keeps existing
 /// `error.localizedDescription` consumers working.
-enum ChecksumServiceError: Error, LocalizedError, Equatable {
+///
+/// `readFailed(URL, Error)` is the catch-all for any underlying read failure that
+/// doesn't fit the other cases. Wrapping rather than rethrowing means callers
+/// only need to know about `ChecksumServiceError` and `ChecksumError` to handle
+/// every failure path — the underlying `Error` is preserved as the associated
+/// value for diagnostics or logging.
+///
+/// `Equatable` is intentionally *not* synthesized: `readFailed`'s associated
+/// `Error` doesn't conform to `Equatable`, so manual conformance would have to
+/// elide that field. Tests use pattern matching (`case .fileNotFound = error`)
+/// which doesn't require `Equatable`.
+enum ChecksumServiceError: Error, LocalizedError {
     case fileNotFound(URL)
     case iCloudNotDownloaded(URL)
     case unreadable(URL)
+    case readFailed(URL, underlyingError: Error)
 
     var errorDescription: String? {
         switch self {
@@ -32,6 +44,8 @@ enum ChecksumServiceError: Error, LocalizedError, Equatable {
             return "File is in iCloud but not downloaded: \(url.lastPathComponent)"
         case .unreadable(let url):
             return "File is not readable: \(url.lastPathComponent)"
+        case .readFailed(let url, let underlying):
+            return "Failed to read \(url.lastPathComponent): \(underlying.localizedDescription)"
         }
     }
 }
@@ -65,8 +79,13 @@ enum ChecksumService {
     static func sha256(
         for fileURL: URL, shouldCancel: @Sendable @escaping () -> Bool
     ) throws -> String {
-        // iCloud-not-downloaded check (semantic, not TOCTOU — the resource value isn't
-        // surfaced from a CryptoKit read in any reliable way).
+        // iCloud-not-downloaded check kept explicit because
+        // `ubiquitousItemDownloadingStatus` isn't reliably surfaced through a CryptoKit
+        // read; without this check the read could either silently trigger an iCloud
+        // download or fail with a confusing native error. There's still a tiny
+        // (microsecond-scale) TOCTOU window between this check and the read — the OS
+        // could begin downloading in that window — but the alternative (no check) is
+        // strictly worse for diagnostic clarity.
         if let status = try? fileURL.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey])
             .ubiquitousItemDownloadingStatus,
             status == .notDownloaded
@@ -97,12 +116,17 @@ enum ChecksumService {
             case NSFileReadNoPermissionError:
                 throw ChecksumServiceError.unreadable(fileURL)
             default:
-                throw nsError
+                throw ChecksumServiceError.readFailed(fileURL, underlyingError: nsError)
             }
+        } catch {
+            // Catch-all for any non-Cocoa Error (e.g., POSIXError if a future call site
+            // bypasses Foundation wrappers). Wrap rather than rethrow so the caller's
+            // contract stays "ChecksumServiceError | ChecksumError | CancellationError".
+            throw ChecksumServiceError.readFailed(fileURL, underlyingError: error)
         }
-        // Any non-Cocoa error bubbles up to the caller as-is. Returning a size-based
-        // pseudo-checksum here would silently treat distinct files as identical when
-        // reads fail under load — unacceptable for a backup tool.
+        // Returning a size-based pseudo-checksum here would silently treat distinct
+        // files as identical when reads fail under load — unacceptable for a backup
+        // tool. Removed in PR #107.
     }
 
     /// Async wrapper around `sha256(for:shouldCancel:)` that bridges the synchronous,

--- a/ImageIntact/Models/ChecksumService.swift
+++ b/ImageIntact/Models/ChecksumService.swift
@@ -55,18 +55,23 @@ enum ChecksumService {
     ///
     /// Throws:
     /// - `ChecksumServiceError.iCloudNotDownloaded(url)` — file is in iCloud but not yet
-    ///   downloaded locally. Detected up front via `ubiquitousItemDownloadingStatus`
-    ///   resource value (semantic check, not TOCTOU; the underlying read would either
-    ///   silently trigger a download or fail with a confusing native error).
+    ///   downloaded locally. Detected up front via `ubiquitousItemDownloadingStatus`.
+    ///   Tiny TOCTOU window between the check and the read is acceptable — the
+    ///   alternative (no check) is strictly worse for diagnostic clarity.
     /// - `ChecksumServiceError.fileNotFound(url)` — mapped from
     ///   `NSCocoaErrorDomain` + `NSFileReadNoSuchFileError` raised by the read.
     /// - `ChecksumServiceError.unreadable(url)` — mapped from
     ///   `NSCocoaErrorDomain` + `NSFileReadNoPermissionError` raised by the read.
+    /// - `ChecksumServiceError.readFailed(url, underlyingError:)` — catch-all wrapper
+    ///   around any other read failure (corrupt file, I/O error, POSIX error from a
+    ///   future call site that bypasses Foundation). Underlying error is preserved
+    ///   for diagnostics.
     /// - `ChecksumError.cancelled` — propagated from `OptimizedChecksum` when the
-    ///   `shouldCancel` closure returns true, or when a `CancellationError` is caught
-    ///   from the surrounding `Task`.
-    /// - Any other `NSError` from the read is rethrown as-is (e.g., I/O errors,
-    ///   filesystem corruption).
+    ///   `shouldCancel` closure returns true.
+    /// - `CancellationError` — propagated as-is from a cancelled parent `Task` to
+    ///   preserve Swift structured-concurrency semantics. (Wrapping it as a
+    ///   domain-specific error would cause `TaskGroup` siblings to treat it as a
+    ///   regular failure rather than cooperative cancellation.)
     ///
     /// The previous size-based fallback (`"size:%016x"`) was removed in PR #107 —
     /// for a verification tool, masking a read failure with a fake hash is a
@@ -106,9 +111,12 @@ enum ChecksumService {
         } catch let checksumError as ChecksumError {
             // Never swallow ChecksumError (includes .cancelled) — rethrow immediately
             throw checksumError
-        } catch is CancellationError {
-            // Never swallow Swift Task cancellation either
-            throw ChecksumError.cancelled
+        } catch let cancellation as CancellationError {
+            // Rethrow Swift's structured-concurrency cancellation as-is. Wrapping it
+            // as ChecksumError.cancelled would cause a parent TaskGroup to treat it
+            // as a regular failure rather than cooperative cancellation, which would
+            // not unwind sibling tasks correctly.
+            throw cancellation
         } catch let nsError as NSError where nsError.domain == NSCocoaErrorDomain {
             switch nsError.code {
             case NSFileReadNoSuchFileError, NSFileNoSuchFileError:

--- a/ImageIntactTests/NativeChecksumTests.swift
+++ b/ImageIntactTests/NativeChecksumTests.swift
@@ -141,6 +141,34 @@ final class NativeChecksumTests: XCTestCase {
         }
     }
 
+    /// Regression test for the `.readFailed` catch-all wrapping introduced when
+    /// the typed enum was added (#108 PR #112). Pointing the service at a
+    /// directory triggers an `NSCocoaErrorDomain` error that is neither
+    /// `NSFileReadNoSuchFileError` nor `NSFileReadNoPermissionError`, so it must
+    /// surface as `ChecksumServiceError.readFailed(url, underlyingError:)` rather
+    /// than as a raw NSError.
+    func testSHA256ChecksumForDirectoryWrapsAsReadFailed() throws {
+        let dir = testDirectory.appendingPathComponent("not-a-file-its-a-directory")
+        try FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true
+        )
+
+        XCTAssertThrowsError(
+            try ChecksumService.sha256(for: dir, shouldCancel: { false })
+        ) { error in
+            guard let serviceError = error as? ChecksumServiceError else {
+                XCTFail("Expected ChecksumServiceError, got: \(type(of: error)) \(error)")
+                return
+            }
+            guard case .readFailed(let url, let underlying) = serviceError else {
+                XCTFail("Expected ChecksumServiceError.readFailed, got: \(serviceError)")
+                return
+            }
+            XCTAssertEqual(url, dir, "Error should carry the offending URL")
+            XCTAssertNotNil(underlying.localizedDescription, "Underlying error should be preserved")
+        }
+    }
+
     func testSHA256ChecksumForBinaryFile() throws {
         // Create binary file with various byte patterns
         let testFile = testDirectory.appendingPathComponent("binary.dat")

--- a/ImageIntactTests/NativeChecksumTests.swift
+++ b/ImageIntactTests/NativeChecksumTests.swift
@@ -95,9 +95,13 @@ final class NativeChecksumTests: XCTestCase {
         let nonExistent = testDirectory.appendingPathComponent("does-not-exist.txt")
 
         XCTAssertThrowsError(try ChecksumService.sha256(for: nonExistent, shouldCancel: { false })) { error in
-            let nsError = error as NSError
-            XCTAssertEqual(nsError.domain, "ImageIntact", "Should be ImageIntact error")
-            XCTAssertEqual(nsError.code, 1, "Should be file not exist error")
+            guard let serviceError = error as? ChecksumServiceError,
+                  case .fileNotFound(let url) = serviceError
+            else {
+                XCTFail("Expected ChecksumServiceError.fileNotFound, got: \(error)")
+                return
+            }
+            XCTAssertEqual(url, nonExistent, "Error should carry the offending URL")
         }
     }
 
@@ -127,9 +131,13 @@ final class NativeChecksumTests: XCTestCase {
         XCTAssertThrowsError(
             try ChecksumService.sha256(for: testFile, shouldCancel: { false })
         ) { error in
-            let nsError = error as NSError
-            XCTAssertEqual(nsError.domain, "ImageIntact", "Should be ImageIntact error")
-            XCTAssertEqual(nsError.code, 1, "Should be file-not-readable error")
+            guard let serviceError = error as? ChecksumServiceError,
+                  case .unreadable(let url) = serviceError
+            else {
+                XCTFail("Expected ChecksumServiceError.unreadable, got: \(error)")
+                return
+            }
+            XCTAssertEqual(url, testFile, "Error should carry the offending URL")
         }
     }
 


### PR DESCRIPTION
## Summary

Closes items 1, 4, 5, 6 of #108.

## Item 1 — Typed `ChecksumServiceError` enum

Replaces the hardcoded `NSError(domain: "ImageIntact", code: 1/7, ...)` pattern (carried over from `BackupManager`) with a strongly-typed Swift enum:

```swift
enum ChecksumServiceError: Error, LocalizedError, Equatable {
    case fileNotFound(URL)
    case iCloudNotDownloaded(URL)
    case unreadable(URL)
}
```

`LocalizedError` for `error.localizedDescription` consumers. `Equatable` for cleaner test assertions. Each case carries the offending `URL` so callers can report it without preserving it from the call site.

### Callsite audit
Pre-flight grep for callers catching `domain == "ImageIntact" && code == 1/7`: **zero production callers**. Two test sites asserted on the codes — both migrated to the typed pattern in this PR. Safe migration.

## Item 4 — Drop TOCTOU pre-checks

The pre-existing `FileManager.fileExists` and `isReadableFile` guards were a TOCTOU anti-pattern (file state can change between the check and the read). They only existed to produce specific NSError codes.

Now the read is attempted directly; native `NSCocoaErrorDomain` errors are mapped to typed cases:

| Native | Typed |
|---|---|
| `NSFileReadNoSuchFileError` / `NSFileNoSuchFileError` | `.fileNotFound(url)` |
| `NSFileReadNoPermissionError` | `.unreadable(url)` |
| (other `NSError`) | rethrown as-is |

The iCloud-not-downloaded check is **kept** — it's a semantic check on `ubiquitousItemDownloadingStatus`, not a TOCTOU pre-check. The underlying CryptoKit read would either silently trigger an iCloud download or fail with a confusing native error otherwise.

## Items 5, 6 — Decouple from `ApplicationLogger.shared`

`ChecksumService` no longer calls `ApplicationLogger.shared.warning(...)` for the iCloud-not-downloaded path. The typed error carries the URL; the caller (which has job-level context) decides whether and how to log. This is consistent with "ChecksumService is a stateless utility, callers own logging."

Item 5 (PII redaction) becomes moot for `ChecksumService` specifically once the logging is removed. The broader codebase audit is a separate project concern, not addressed here.

## Tests

- `testSHA256ChecksumForNonExistentFile` — updated to assert `ChecksumServiceError.fileNotFound(url)` with URL match.
- `testSHA256ChecksumForUnreadableFileThrows` — updated to assert `ChecksumServiceError.unreadable(url)` with URL match.

Both use the typed pattern-match idiom:

```swift
guard let serviceError = error as? ChecksumServiceError,
      case .fileNotFound(let url) = serviceError
else {
    XCTFail("Expected ChecksumServiceError.fileNotFound, got: \(error)")
    return
}
XCTAssertEqual(url, nonExistent)
```

Skipping an `iCloudNotDownloaded` test — mocking `ubiquitousItemDownloadingStatus` requires Foundation private API or a protocol-injected resource-value reader; not worth the cost given the path is exercised by manifest-comparison code in production.

**Tests:** 410 passed / 10 failed (same pre-existing baseline).

## Test plan

- [x] Type system compiles (typed errors propagate through 4 callers + 6 test files unchanged)
- [x] `testSHA256ChecksumForNonExistentFile` passes with new typed assertion
- [x] `testSHA256ChecksumForUnreadableFileThrows` passes with new typed assertion
- [x] All other checksum suites unaffected