### PR TITLE
refactor: trim BackupManager init + state declarations (#103)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -51,8 +51,6 @@ class BackupManager {
     var sessionID = UUID().uuidString
     var shouldCancel = false
     var debugLog: [String] = []
-    var hasWrittenDebugLog = false
-    var lastDebugLogPath: URL?
 
     // Progress tracking delegated to ProgressTracker
     let progressTracker = ProgressTracker()
@@ -165,23 +163,7 @@ class BackupManager {
     // See: GH issue #91, finding #8.
     var organizationName: String = "" {
         didSet {
-            var cleaned = organizationName
-                .replacingOccurrences(of: "/", with: "_")
-                .replacingOccurrences(of: "\\", with: "_")
-                .replacingOccurrences(of: ":", with: "_")  // macOS Finder path separator
-                .replacingOccurrences(of: "\0", with: "")  // null bytes
-                .trimmingCharacters(in: .whitespacesAndNewlines.union(CharacterSet(charactersIn: ".")))
-            // APFS/HFS+ limit is 255 UTF-8 bytes, not characters.
-            if cleaned.utf8.count > 255 {
-                var truncated = ""
-                for char in cleaned {
-                    let next = truncated + String(char)
-                    if next.utf8.count > 255 { break }
-                    truncated = next
-                }
-                cleaned = truncated
-            }
-            let sanitized = cleaned
+            let sanitized = SmartFolderName.sanitize(organizationName)
             if sanitized != organizationName {
                 organizationName = sanitized
             }
@@ -237,7 +219,6 @@ class BackupManager {
     }
 
     var logEntries: [LogEntry] = []
-    private var currentOperation: DispatchWorkItem?
     var currentOrchestrator: BackupOrchestrator?
 
     // MARK: - Initialization
@@ -278,13 +259,14 @@ class BackupManager {
             return
         }
 
-        // Initialize file type filter on source manager
-        initializeFileTypeFilter()
-
         // Restore last session if enabled
         if PreferencesManager.shared.restoreLastSession {
             destinationManager.loadFromSession()
-            loadSourceFromSession()
+            if let restoredURL = sourceManager.loadFromSession(), !BackupManager.isRunningTests {
+                Task { [sourceManager] in
+                    await sourceManager.scanSourceFolder(restoredURL)
+                }
+            }
         } else {
             destinationManager.initializeEmpty()
             logInfo("Initialized with single empty destination slot")
@@ -292,44 +274,6 @@ class BackupManager {
 
         // Validate and analyze loaded destinations
         destinationManager.validateAndAnalyzeDestinations()
-    }
-
-    // MARK: - Initialization Helpers
-
-    /// Initialize the file type filter from user preferences
-    private func initializeFileTypeFilter() {
-        let filterPref = PreferencesManager.shared.defaultFileTypeFilter
-        switch filterPref {
-        case "photos":
-            sourceManager.fileTypeFilter = .photosOnly
-        case "raw":
-            sourceManager.fileTypeFilter = .rawOnly
-        case "videos":
-            sourceManager.fileTypeFilter = .videosOnly
-        default:
-            sourceManager.fileTypeFilter = FileTypeFilter()
-        }
-    }
-
-    /// Load source URL from saved bookmark and trigger scan
-    private func loadSourceFromSession() {
-        guard let savedSourceURL = BookmarkManager.loadBookmark(forKey: BookmarkManager.sourceKey) else { return }
-
-        let canAccess = savedSourceURL.startAccessingSecurityScopedResource()
-        if canAccess {
-            savedSourceURL.stopAccessingSecurityScopedResource()
-            sourceManager.sourceURL = savedSourceURL
-            logInfo("Loaded source: \(savedSourceURL.lastPathComponent)")
-            // Skip async scan in tests to avoid race conditions with tearDown
-            if !BackupManager.isRunningTests {
-                Task {
-                    await sourceManager.scanSourceFolder(savedSourceURL)
-                }
-            }
-        } else {
-            logWarning("Saved source bookmark is invalid, clearing...")
-            UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
-        }
     }
 
     // MARK: - Public Methods
@@ -604,7 +548,6 @@ class BackupManager {
         logEntries = []
         shouldCancel = false
         debugLog = []
-        hasWrittenDebugLog = false
 
         // Save organization folder name to recent list and as last used
         if !organizationName.isEmpty {
@@ -669,9 +612,6 @@ class BackupManager {
             self?.currentOrchestrator?.cancel()
         }
 
-        // Cancel any pending operation
-        currentOperation?.cancel()
-
         // Clean up resources
         Task { [weak self] in
             await self?.resourceManager.cleanup()
@@ -700,7 +640,6 @@ class BackupManager {
 
         // Clear orchestrator reference
         currentOrchestrator = nil
-        currentOperation = nil
 
         // Note: Core Data will manage its own memory
         EventLogger.shared.resetContexts()

--- a/ImageIntact/Models/SmartFolderName.swift
+++ b/ImageIntact/Models/SmartFolderName.swift
@@ -46,4 +46,32 @@ enum SmartFolderName {
             .replacingOccurrences(of: " ", with: "_")
             .replacingOccurrences(of: "__+", with: "_", options: .regularExpression)
     }
+
+    /// Sanitizes a string for use as a filesystem folder name.
+    ///
+    /// - Replaces `/`, `\`, and `:` with underscores.
+    /// - Removes null bytes.
+    /// - Trims leading/trailing whitespace and dots.
+    /// - Truncates to ≤ 255 UTF-8 bytes without splitting multi-byte characters.
+    ///
+    /// Pure function — no side effects. Idempotent: `sanitize(sanitize(x)) == sanitize(x)`.
+    static func sanitize(_ name: String) -> String {
+        var cleaned = name
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "\\", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines.union(CharacterSet(charactersIn: ".")))
+        // APFS/HFS+ limit is 255 UTF-8 bytes, not characters.
+        if cleaned.utf8.count > 255 {
+            var truncated = ""
+            for char in cleaned {
+                let next = truncated + String(char)
+                if next.utf8.count > 255 { break }
+                truncated = next
+            }
+            cleaned = truncated
+        }
+        return cleaned
+    }
 }

--- a/ImageIntact/Models/SourceManager.swift
+++ b/ImageIntact/Models/SourceManager.swift
@@ -48,6 +48,42 @@ class SourceManager {
         // Load preferences
         self.includeSubdirectories = PreferencesManager.shared.includeSubdirectories
         self.excludeCacheFiles = PreferencesManager.shared.excludeCacheFiles
+        self.fileTypeFilter = Self.fileTypeFilterFromPreferences()
+    }
+
+    private static func fileTypeFilterFromPreferences() -> FileTypeFilter {
+        switch PreferencesManager.shared.defaultFileTypeFilter {
+        case "photos": return .photosOnly
+        case "raw":    return .rawOnly
+        case "videos": return .videosOnly
+        default:       return FileTypeFilter()
+        }
+    }
+
+    // MARK: - Session Restore
+
+    /// Restores the source URL from the saved security-scoped bookmark.
+    ///
+    /// Returns the restored URL on success, or nil if no bookmark exists or access
+    /// is denied (in which case the stale bookmark is cleared from UserDefaults).
+    /// The caller is responsible for triggering any subsequent async scan — this
+    /// method deliberately does NOT start one, so test mode can suppress it cleanly.
+    @MainActor
+    func loadFromSession() -> URL? {
+        guard let savedSourceURL = BookmarkManager.loadBookmark(forKey: BookmarkManager.sourceKey) else {
+            return nil
+        }
+        let canAccess = savedSourceURL.startAccessingSecurityScopedResource()
+        if canAccess {
+            savedSourceURL.stopAccessingSecurityScopedResource()
+            sourceURL = savedSourceURL
+            logInfo("Loaded source: \(savedSourceURL.lastPathComponent)")
+            return savedSourceURL
+        } else {
+            logWarning("Saved source bookmark is invalid, clearing...")
+            UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+            return nil
+        }
     }
 
     // MARK: - File Scanning

--- a/ImageIntactTests/SmartFolderNameTests.swift
+++ b/ImageIntactTests/SmartFolderNameTests.swift
@@ -66,4 +66,113 @@ final class SmartFolderNameTests: XCTestCase {
         let url = URL(fileURLWithPath: "/Users/me/Backups/.tmpdir")
         XCTAssertEqual(SmartFolderName.from(url: url), "Backups")
     }
+
+    // MARK: - sanitize(_:) (AMUX-20 / GH #103 — TDD red phase)
+    // NOTE: SmartFolderName.sanitize(_:) does not exist yet. These tests will
+    // fail to compile until the static method is added to SmartFolderName.swift.
+
+    /// Empty string → empty string.
+    func testSanitize_emptyString() {
+        XCTAssertEqual(SmartFolderName.sanitize(""), "")
+    }
+
+    /// Plain ASCII name without special characters → unchanged.
+    func testSanitize_plainASCII_unchanged() {
+        XCTAssertEqual(SmartFolderName.sanitize("MyFolder"), "MyFolder")
+    }
+
+    /// Forward slash → underscore.
+    func testSanitize_forwardSlash_replacedWithUnderscore() {
+        XCTAssertEqual(SmartFolderName.sanitize("foo/bar"), "foo_bar")
+    }
+
+    /// Backslash → underscore.
+    func testSanitize_backslash_replacedWithUnderscore() {
+        XCTAssertEqual(SmartFolderName.sanitize("foo\\bar"), "foo_bar")
+    }
+
+    /// Colon → underscore (macOS Finder path separator).
+    func testSanitize_colon_replacedWithUnderscore() {
+        XCTAssertEqual(SmartFolderName.sanitize("foo:bar"), "foo_bar")
+    }
+
+    /// Null byte → removed entirely (not replaced).
+    func testSanitize_nullByte_removed() {
+        XCTAssertEqual(SmartFolderName.sanitize("foo\0bar"), "foobar")
+    }
+
+    /// Leading and trailing whitespace is trimmed.
+    func testSanitize_whitespace_trimmed() {
+        XCTAssertEqual(SmartFolderName.sanitize("  foo  "), "foo")
+    }
+
+    /// Leading dots are trimmed.
+    func testSanitize_leadingDots_trimmed() {
+        XCTAssertEqual(SmartFolderName.sanitize("...foo..."), "foo")
+    }
+
+    /// Combined dots and whitespace (e.g. ".  Foo  .") → "Foo".
+    func testSanitize_dotsAndWhitespaceCombined_trimmed() {
+        XCTAssertEqual(SmartFolderName.sanitize(".  Foo  ."), "Foo")
+    }
+
+    /// A 255-byte ASCII string is returned unchanged (on the boundary — no truncation).
+    func testSanitize_exactly255ByteString_unchanged() {
+        let input = String(repeating: "a", count: 255)
+        XCTAssertEqual(input.utf8.count, 255, "Precondition: input must be exactly 255 UTF-8 bytes")
+        let result = SmartFolderName.sanitize(input)
+        XCTAssertEqual(result, input, "A 255-byte string must not be truncated")
+        XCTAssertEqual(result.utf8.count, 255)
+    }
+
+    /// A 256-byte ASCII string is truncated to ≤ 255 bytes.
+    func testSanitize_256ByteString_truncatedTo255() {
+        let input = String(repeating: "a", count: 256)
+        XCTAssertEqual(input.utf8.count, 256, "Precondition: input must be exactly 256 UTF-8 bytes")
+        let result = SmartFolderName.sanitize(input)
+        XCTAssertLessThanOrEqual(result.utf8.count, 255,
+                                 "A 256-byte string must be truncated to ≤ 255 UTF-8 bytes")
+    }
+
+    /// When the truncation boundary falls inside a multi-byte UTF-8 character,
+    /// the partial character is dropped entirely (no replacement characters).
+    /// Input: 253 ASCII "a" chars (253 bytes) + "🍕" (4 bytes) = 257 bytes total.
+    /// Expected: the pizza emoji is dropped; result is 253 "a"s.
+    func testSanitize_truncation_doesNotSplitMultibyteCharacter() {
+        let input = String(repeating: "a", count: 253) + "🍕"
+        XCTAssertEqual(input.utf8.count, 257,
+                       "Precondition: input must be 257 UTF-8 bytes (253 ASCII + 4-byte emoji)")
+        let result = SmartFolderName.sanitize(input)
+        XCTAssertLessThanOrEqual(result.utf8.count, 255,
+                                 "Result must be ≤ 255 UTF-8 bytes")
+        XCTAssertFalse(result.contains("\u{FFFD}"),
+                       "Result must not contain the Unicode replacement character (partial decode)")
+        // The emoji is 4 bytes — including it would exceed 255 — so it must be absent.
+        XCTAssertFalse(result.contains("🍕"),
+                       "Partial emoji at the truncation boundary must be dropped entirely")
+        XCTAssertEqual(result, String(repeating: "a", count: 253),
+                       "Result should be exactly the 253 ASCII characters before the emoji")
+    }
+
+    /// sanitize is idempotent: applying it twice yields the same result as once.
+    func testSanitize_idempotent_slashInput() {
+        let input = "foo/bar"
+        XCTAssertEqual(SmartFolderName.sanitize(SmartFolderName.sanitize(input)),
+                       SmartFolderName.sanitize(input),
+                       "sanitize must be idempotent for slash-containing input")
+    }
+
+    func testSanitize_idempotent_dotsAndWhitespace() {
+        let input = "  .test.  "
+        XCTAssertEqual(SmartFolderName.sanitize(SmartFolderName.sanitize(input)),
+                       SmartFolderName.sanitize(input),
+                       "sanitize must be idempotent for dot/whitespace-padded input")
+    }
+
+    func testSanitize_idempotent_longString() {
+        let input = String(repeating: "a", count: 300)
+        XCTAssertEqual(SmartFolderName.sanitize(SmartFolderName.sanitize(input)),
+                       SmartFolderName.sanitize(input),
+                       "sanitize must be idempotent for a string that requires truncation")
+    }
 }

--- a/ImageIntactTests/SourceManagerTests.swift
+++ b/ImageIntactTests/SourceManagerTests.swift
@@ -6,6 +6,9 @@
 //  prepareSource(at:) — the state-mutation path extracted from
 //  BackupManager.setSource (#103 / AMUX-18).
 //
+//  AMUX-20 / GH #103: extended with loadFromSession() and
+//  file-type-filter preference-loading tests (TDD red phase).
+//
 
 import XCTest
 
@@ -13,6 +16,25 @@ import XCTest
 
 @MainActor
 final class SourceManagerTests: XCTestCase {
+
+    // MARK: - Lifecycle
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Clear the source bookmark so loadFromSession tests start clean.
+        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        // Reset file-type-filter preference to a known baseline.
+        PreferencesManager.shared.resetToDefaults()
+    }
+
+    override func tearDown() async throws {
+        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        PreferencesManager.shared.resetToDefaults()
+        try await super.tearDown()
+    }
+
+    // MARK: - Existing tests (unchanged)
+
     /// `prepareSource` clears stale scan state from a previous source. The
     /// auto-scan is suppressed under `BackupManager.isRunningTests`, so we can
     /// assert the synchronous post-conditions deterministically.
@@ -104,5 +126,141 @@ final class SourceManagerTests: XCTestCase {
         XCTAssertEqual(manager.sourceURL, url, "Source URL must NOT be cleared on failure")
         XCTAssertEqual(manager.sourceFileTypes, [.jpeg: 5], "File types must NOT be cleared on failure")
         XCTAssertEqual(manager.scanProgress, "preserved", "Scan progress must NOT be cleared on failure")
+    }
+
+    // MARK: - loadFromSession (AMUX-20 / GH #103 — TDD red phase)
+    // NOTE: loadFromSession() does not exist yet. These tests will fail to
+    // compile until the implementation is added to SourceManager.swift.
+
+    /// loadFromSession returns nil when UserDefaults has no entry for
+    /// BookmarkManager.sourceKey — the common "fresh launch" path.
+    func testLoadFromSession_returnsNilWhenNoBookmark() {
+        // setUp already clears the key; confirm baseline.
+        XCTAssertNil(UserDefaults.standard.data(forKey: BookmarkManager.sourceKey),
+                     "Precondition: no bookmark data in UserDefaults")
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        let result = manager.loadFromSession()
+        XCTAssertNil(result, "loadFromSession must return nil when no bookmark is stored")
+    }
+
+    /// loadFromSession returns nil and removes the stale bookmark from
+    /// UserDefaults when a bookmark entry exists but security-scoped access
+    /// fails. In the XCTest harness (non-sandboxed), startAccessingSecurityScopedResource
+    /// returns false for paths outside the sandbox, which exercises this branch.
+    ///
+    /// If the test environment grants access for the temp URL (sandbox is active),
+    /// the test will follow the success path instead — that is documented here so
+    /// the CI failure is understandable. The success path is covered separately.
+    func testLoadFromSession_returnsNilAndClearsDefaultsWhenAccessFails() {
+        // Plant a bookmark for a path that is unlikely to be accessible in the
+        // sandboxed test runner. We create a temp dir so the bookmark data itself
+        // resolves (i.e. loadBookmark returns a URL), giving startAccessingSecurityScopedResource
+        // a chance to fail on the real file URL with no sandbox entitlement.
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        BookmarkManager.saveBookmark(url: tempDir, key: BookmarkManager.sourceKey)
+        XCTAssertNotNil(UserDefaults.standard.data(forKey: BookmarkManager.sourceKey),
+                        "Precondition: bookmark data must be present before calling loadFromSession")
+
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        let result = manager.loadFromSession()
+
+        // In the non-sandboxed test runner, access fails → result is nil and key is cleared.
+        // In a sandboxed runner where access succeeds, result is the URL (success path).
+        // Either outcome is valid; we assert the invariant: if nil is returned the key is gone.
+        if result == nil {
+            XCTAssertNil(UserDefaults.standard.data(forKey: BookmarkManager.sourceKey),
+                         "When loadFromSession returns nil, it must clear the stale bookmark key")
+            XCTAssertNil(manager.sourceURL,
+                         "sourceURL must not be set when loadFromSession returns nil")
+        } else {
+            // Success path exercised — covered by the dedicated success test.
+            XCTAssertEqual(manager.sourceURL, result,
+                           "When loadFromSession returns a URL, sourceURL must match")
+        }
+    }
+
+    /// loadFromSession sets sourceURL and returns the URL when the bookmark
+    /// resolves and security-scoped access succeeds. This test uses the temp
+    /// directory but notes that access success depends on sandbox entitlements.
+    func testLoadFromSession_setsSourceURLAndReturnsURLOnSuccess() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        BookmarkManager.saveBookmark(url: tempDir, key: BookmarkManager.sourceKey)
+
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        let result = manager.loadFromSession()
+
+        // If access succeeds, result must equal sourceURL.
+        if let restoredURL = result {
+            XCTAssertEqual(manager.sourceURL, restoredURL,
+                           "sourceURL must be set to the restored URL on success")
+        }
+        // If access fails (non-sandboxed runner), result is nil — covered by the
+        // access-failure test. Either outcome is valid here.
+    }
+
+    /// loadFromSession must NOT trigger an async scan. isScanning must be false
+    /// immediately after the synchronous call returns.
+    func testLoadFromSession_doesNotTriggerAsyncScan() {
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        // No bookmark planted — loadFromSession returns nil immediately.
+        _ = manager.loadFromSession()
+        XCTAssertFalse(manager.isScanning,
+                       "loadFromSession must not start an async scan; scanning is the caller's responsibility")
+    }
+
+    // MARK: - File-type-filter preference loading on init (AMUX-20 / GH #103)
+    // These test that SourceManager.init reads defaultFileTypeFilter from
+    // PreferencesManager and maps it to the correct FileTypeFilter preset.
+    // The mapping does not exist yet in SourceManager.init — these tests will
+    // fail until the implementation lands.
+
+    /// "photos" preference → .photosOnly filter on init.
+    func testInit_fileTypeFilter_photosPreference() {
+        PreferencesManager.shared.defaultFileTypeFilter = "photos"
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        XCTAssertEqual(manager.fileTypeFilter, FileTypeFilter.photosOnly,
+                       "\"photos\" pref should produce .photosOnly filter at init")
+    }
+
+    /// "raw" preference → .rawOnly filter on init.
+    func testInit_fileTypeFilter_rawPreference() {
+        PreferencesManager.shared.defaultFileTypeFilter = "raw"
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        XCTAssertEqual(manager.fileTypeFilter, FileTypeFilter.rawOnly,
+                       "\"raw\" pref should produce .rawOnly filter at init")
+    }
+
+    /// "videos" preference → .videosOnly filter on init.
+    func testInit_fileTypeFilter_videosPreference() {
+        PreferencesManager.shared.defaultFileTypeFilter = "videos"
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        XCTAssertEqual(manager.fileTypeFilter, FileTypeFilter.videosOnly,
+                       "\"videos\" pref should produce .videosOnly filter at init")
+    }
+
+    /// Unrecognised preference string → default FileTypeFilter() (include-all) on init.
+    func testInit_fileTypeFilter_unrecognisedPreference() {
+        PreferencesManager.shared.defaultFileTypeFilter = "garbage"
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        XCTAssertEqual(manager.fileTypeFilter, FileTypeFilter(),
+                       "Unrecognised pref string should produce the default include-all filter at init")
+    }
+
+    /// "all" (the @AppStorage default) → default FileTypeFilter() (include-all) on init.
+    /// This also covers the "nil/missing" case since @AppStorage returns "all" when the
+    /// key is absent.
+    func testInit_fileTypeFilter_allPreference() {
+        PreferencesManager.shared.defaultFileTypeFilter = "all"
+        let manager = SourceManager(fileOperations: MockFileOperations())
+        XCTAssertEqual(manager.fileTypeFilter, FileTypeFilter(),
+                       "\"all\" pref should produce the default include-all filter at init")
     }
 }


### PR DESCRIPTION
## Summary

- **Dead state removed:** `lastDebugLogPath` (no readers), `hasWrittenDebugLog` (never set to true), `currentOperation` (never assigned — its `.cancel()` at the call site was a no-op)
- **Moved to `SourceManager`:** `loadSourceFromSession()` → `SourceManager.loadFromSession()`, symmetric with the existing `destinationManager.loadFromSession()`; file-type-filter preference loading moved into `SourceManager.init`, matching the pattern for `includeSubdirectories`/`excludeCacheFiles`. Removes `BackupManager.initializeFileTypeFilter()`.
- **Moved to `SmartFolderName.sanitize(_:)`:** `organizationName` didSet sanitization body extracted to a new static. The didSet shell and re-entrancy guard remain on `BackupManager` so runtime behavior is unchanged.
- **BackupManager.swift:** 777 → 716 lines (-61)

## Tests

- 23 new test cases: 15 for `SmartFolderName.sanitize`, 4 for `SourceManager.loadFromSession`, 4 for file-type-filter init in `SourceManager`
- All pass under `-testPlan Fast` (used as workaround for the pre-existing default-test-plan loading bug)
- Pre-existing failures: 10 cases in `ManifestBuilderFilterTests` + `SubdirectoryTraversalTests` — confirmed unrelated to this refactor, untouched

## Panel review

- Round 1: 2 Blockers, 3 High, 5 Medium, 3 Low
- All Blocker and High findings are **pre-existing** in `BackupManager.swift` and out-of-scope for this refactor:
  - *Blocker "Orchestrator Cancellation Race"*: concerns `currentOrchestrator` — untouched; AMUX-20 only removed `currentOperation` (a dead field)
  - *Blocker "NSAlert in business logic"*: `setDestination`/`runBackup` — untouched
  - *High "10s cleanupMemory race"*: `cleanupMemory()` body — untouched
  - *High "isRunningTests checks"*: design doc explicitly keeps the guard at the call site; not introduced by this PR
  - *High "totalBytesToCopy disk space check"*: `runBackup()` — untouched
- The one finding touching this diff (Low: `organizationName` init bypass) was also pre-existing — the pre-refactor init assigned `lastUsedName` without sanitization identically; no regression introduced
- No fixes required; no additional rounds needed

## Refs

AMUX-20, Refs #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)