### PR TITLE
refactor: extract destination-alert presentation from BackupManager (#103)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -185,6 +185,7 @@ class BackupManager {
     var showDuplicateWarning = false
     var duplicateAnalyses: [URL: DuplicateDetector.DuplicateAnalysis]?
     let duplicateDetector: DuplicateDetectorProtocol
+    let destinationAlertPresenter: DestinationAlertPresenting
     var skipExactDuplicates = true
     var skipRenamedDuplicates = false
 
@@ -228,7 +229,8 @@ class BackupManager {
         notificationService: NotificationProtocol? = nil,
         driveAnalyzer: DriveAnalyzerProtocol? = nil,
         diskSpaceChecker: DiskSpaceProtocol? = nil,
-        duplicateDetector: DuplicateDetectorProtocol? = nil
+        duplicateDetector: DuplicateDetectorProtocol? = nil,
+        destinationAlertPresenter: DestinationAlertPresenting? = nil
     ) {
         // Use provided dependencies or create real implementations
         let resolvedFileOps = fileOperations ?? DefaultFileOperations()
@@ -239,6 +241,7 @@ class BackupManager {
         self.driveAnalyzer = resolvedDriveAnalyzer
         self.diskSpaceChecker = resolvedDiskSpace
         self.duplicateDetector = duplicateDetector ?? DuplicateDetector()
+        self.destinationAlertPresenter = destinationAlertPresenter ?? NSAlertDestinationPresenter()
 
         // Create delegated managers
         self.sourceManager = SourceManager(fileOperations: resolvedFileOps)
@@ -315,36 +318,11 @@ class BackupManager {
                 totalBytesToCopy: totalBytesToCopy
             )
         } catch DestinationError.sameAsSource {
-            if !BackupManager.isRunningTests {
-                let alert = NSAlert()
-                alert.messageText = "Invalid Destination"
-                alert.informativeText = "The destination folder cannot be the same as the source folder."
-                alert.alertStyle = .warning
-                alert.addButton(withTitle: "OK")
-                alert.runModal()
-            }
+            destinationAlertPresenter.presentSameAsSourceAlert()
         } catch DestinationError.duplicateDestination(let idx) {
-            if !BackupManager.isRunningTests {
-                let alert = NSAlert()
-                alert.messageText = "Duplicate Destination"
-                alert.informativeText =
-                    "This folder is already selected as destination #\(idx + 1). Please choose a different folder."
-                alert.alertStyle = .warning
-                alert.addButton(withTitle: "OK")
-                alert.runModal()
-            }
+            destinationAlertPresenter.presentDuplicateDestinationAlert(existingIndex: idx)
         } catch DestinationError.sourceTagConflict(let tagURL) {
-            if !BackupManager.isRunningTests {
-                let alert = NSAlert()
-                alert.messageText = "Source Folder Selected"
-                alert.informativeText =
-                    "This folder was previously used as a source. Using it as a destination will remove the source tag. Do you want to continue?"
-                alert.alertStyle = .warning
-                alert.addButton(withTitle: "Use This Folder")
-                alert.addButton(withTitle: "Cancel")
-                let response = alert.runModal()
-                if response == .alertSecondButtonReturn { return }
-            }
+            guard destinationAlertPresenter.presentSourceTagConflictAlert() else { return }
             sourceManager.removeSourceTag(at: tagURL)
             do {
                 try destinationManager.setDestination(

--- a/ImageIntact/Models/DestinationAlertPresenter.swift
+++ b/ImageIntact/Models/DestinationAlertPresenter.swift
@@ -1,0 +1,63 @@
+//
+//  DestinationAlertPresenter.swift
+//  ImageIntact
+//
+//  Protocol and AppKit implementation for presenting DestinationError alerts.
+//  Extracted from BackupManager.setDestination (AMUX-19, GH #103) to remove
+//  NSAlert calls from the model layer and enable dependency injection in tests.
+//
+//  Design doc: .planning/design/backup-manager-destination-forwarding.md
+//
+
+import AppKit
+
+/// Presents user-facing alerts for `DestinationError` cases caught by
+/// `BackupManager.setDestination`. Injected as a dependency so tests can
+/// substitute a mock and the model layer stays free of AppKit calls.
+@MainActor
+protocol DestinationAlertPresenting {
+    /// "Invalid Destination — same as source" alert. No user response needed.
+    func presentSameAsSourceAlert()
+
+    /// "Duplicate Destination" alert mentioning the existing index. No user response needed.
+    func presentDuplicateDestinationAlert(existingIndex: Int)
+
+    /// "Source Folder Selected" alert. Returns whether the caller should
+    /// proceed with removing the source tag and retrying `setDestination`.
+    /// `true` = user clicked "Use This Folder"; `false` = user cancelled.
+    func presentSourceTagConflictAlert() -> Bool
+}
+
+@MainActor
+struct NSAlertDestinationPresenter: DestinationAlertPresenting {
+    func presentSameAsSourceAlert() {
+        let alert = NSAlert()
+        alert.messageText = "Invalid Destination"
+        alert.informativeText = "The destination folder cannot be the same as the source folder."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    func presentDuplicateDestinationAlert(existingIndex: Int) {
+        let alert = NSAlert()
+        alert.messageText = "Duplicate Destination"
+        alert.informativeText =
+            "This folder is already selected as destination #\(existingIndex + 1). Please choose a different folder."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    func presentSourceTagConflictAlert() -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Source Folder Selected"
+        alert.informativeText =
+            "This folder was previously used as a source. Using it as a destination will remove the source tag. Do you want to continue?"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Use This Folder")
+        alert.addButton(withTitle: "Cancel")
+        let response = alert.runModal()
+        return response == .alertFirstButtonReturn
+    }
+}

--- a/ImageIntactTests/BackupManagerSetDestinationTests.swift
+++ b/ImageIntactTests/BackupManagerSetDestinationTests.swift
@@ -1,0 +1,161 @@
+//
+//  BackupManagerSetDestinationTests.swift
+//  ImageIntactTests
+//
+//  TDD red-phase tests for the destination-forwarding alert extraction (AMUX-19).
+//  These tests reference DestinationAlertPresenting, NSAlertDestinationPresenter,
+//  and the destinationAlertPresenter init parameter on BackupManager — none of
+//  which exist yet. Compile failure here IS the red-phase signal.
+//
+//  Design doc: .planning/design/backup-manager-destination-forwarding.md
+//
+
+import XCTest
+@testable import ImageIntact
+
+@MainActor
+final class BackupManagerSetDestinationTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    var mockFileOps: MockFileOperations!
+    var mockPresenter: MockDestinationAlertPresenter!
+    var backupManager: BackupManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // Clear bookmark and preferences state so init doesn't restore stale data.
+        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        for key in BookmarkManager.destinationKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        PreferencesManager.shared.resetToDefaults()
+
+        mockFileOps = MockFileOperations()
+        mockPresenter = MockDestinationAlertPresenter()
+
+        // New init param (doesn't exist yet — compile failure is expected).
+        backupManager = BackupManager(
+            fileOperations: mockFileOps,
+            destinationAlertPresenter: mockPresenter
+        )
+    }
+
+    override func tearDown() async throws {
+        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        for key in BookmarkManager.destinationKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        PreferencesManager.shared.resetToDefaults()
+
+        backupManager = nil
+        mockPresenter = nil
+        mockFileOps = nil
+
+        try await super.tearDown()
+    }
+
+    private func makeURL(_ path: String) -> URL {
+        URL(fileURLWithPath: path)
+    }
+
+    // MARK: - Tests
+
+    /// sameAsSource error → presenter's sameAsSource method called exactly once.
+    func testSetDestination_sameAsSource_callsPresenter() {
+        let url = makeURL("/Volumes/CardA/DCIM")
+        backupManager.setSource(url)
+
+        backupManager.setDestination(url, at: 0)
+
+        XCTAssertEqual(mockPresenter.presentSameAsSourceAlertCallCount, 1,
+                       "sameAsSource should call presenter exactly once")
+        XCTAssertEqual(mockPresenter.presentDuplicateDestinationAlertCalls.count, 0)
+        XCTAssertEqual(mockPresenter.presentSourceTagConflictAlertCallCount, 0)
+    }
+
+    /// duplicateDestination error → presenter called with the index of the existing destination.
+    func testSetDestination_duplicateDestination_callsPresenterWithIndex() {
+        let source = makeURL("/Volumes/Source/DCIM")
+        let dest = makeURL("/Volumes/BackupB")
+
+        // A source that differs from B (no sameAsSource error).
+        backupManager.setSource(source)
+
+        // Set slot 0 to B.
+        backupManager.setDestination(dest, at: 0)
+
+        // Add a second slot, then set it to B (duplicate of slot 0).
+        backupManager.addDestination()
+        backupManager.setDestination(dest, at: 1)
+
+        XCTAssertEqual(mockPresenter.presentDuplicateDestinationAlertCalls, [0],
+                       "duplicateDestination should call presenter with existingIndex 0")
+        XCTAssertEqual(mockPresenter.presentSameAsSourceAlertCallCount, 0)
+        XCTAssertEqual(mockPresenter.presentSourceTagConflictAlertCallCount, 0)
+    }
+
+    /// sourceTagConflict + presenter returns true → tag removed, destination set.
+    func testSetDestination_sourceTagConflict_proceedTrue_retriesAndSetsDestination() {
+        let dest = makeURL("/Volumes/WasPreviouslySource")
+        let tagFile = dest.appendingPathComponent(".imageintact_source")
+
+        // Plant the source-tag file so checkForSourceTag returns true.
+        mockFileOps.filesExist.insert(tagFile)
+        mockPresenter.sourceTagConflictReturnValue = true
+
+        backupManager.setDestination(dest, at: 0)
+
+        XCTAssertEqual(mockPresenter.presentSourceTagConflictAlertCallCount, 1,
+                       "sourceTagConflict should call presenter once")
+        XCTAssertTrue(mockFileOps.removedItems.contains(tagFile),
+                      "Source tag should be removed when user proceeds")
+        XCTAssertEqual(backupManager.destinationItems[0].url, dest,
+                       "Destination should be set after source tag removal")
+    }
+
+    /// sourceTagConflict + presenter returns false → tag NOT removed, destination NOT set.
+    func testSetDestination_sourceTagConflict_proceedFalse_doesNothing() {
+        let dest = makeURL("/Volumes/WasPreviouslySource")
+        let tagFile = dest.appendingPathComponent(".imageintact_source")
+
+        mockFileOps.filesExist.insert(tagFile)
+        mockPresenter.sourceTagConflictReturnValue = false
+
+        backupManager.setDestination(dest, at: 0)
+
+        XCTAssertEqual(mockPresenter.presentSourceTagConflictAlertCallCount, 1,
+                       "sourceTagConflict should call presenter once even when cancelled")
+        XCTAssertFalse(mockFileOps.removedItems.contains(tagFile),
+                       "Source tag should NOT be removed when user cancels")
+        XCTAssertNil(backupManager.destinationItems[0].url,
+                     "Destination should NOT be set when user cancels")
+    }
+
+    /// Out-of-range index → no presenter calls, no crash.
+    func testSetDestination_indexOutOfRange_logsWithoutAlert() {
+        let url = makeURL("/Volumes/SomeFolder")
+
+        backupManager.setDestination(url, at: 999)
+
+        XCTAssertEqual(mockPresenter.presentSameAsSourceAlertCallCount, 0)
+        XCTAssertEqual(mockPresenter.presentDuplicateDestinationAlertCalls.count, 0)
+        XCTAssertEqual(mockPresenter.presentSourceTagConflictAlertCallCount, 0)
+    }
+
+    /// Happy path — distinct URLs with no source tag → presenter never called, destination set.
+    func testSetDestination_success_doesNotCallPresenter() {
+        let source = makeURL("/Volumes/CardA/DCIM")
+        let dest = makeURL("/Volumes/BackupDrive")
+
+        backupManager.setSource(source)
+        backupManager.setDestination(dest, at: 0)
+
+        XCTAssertEqual(mockPresenter.presentSameAsSourceAlertCallCount, 0)
+        XCTAssertEqual(mockPresenter.presentDuplicateDestinationAlertCalls.count, 0)
+        XCTAssertEqual(mockPresenter.presentSourceTagConflictAlertCallCount, 0)
+        XCTAssertEqual(backupManager.destinationItems[0].url, dest,
+                       "Destination should be set on happy path")
+    }
+}

--- a/ImageIntactTests/DestinationAlertPresenterTests.swift
+++ b/ImageIntactTests/DestinationAlertPresenterTests.swift
@@ -1,0 +1,28 @@
+//
+//  DestinationAlertPresenterTests.swift
+//  ImageIntactTests
+//
+//  Tests for NSAlertDestinationPresenter (AMUX-19).
+//
+//  NOTE: Modal presentation (NSAlert.runModal) cannot be tested in XCTest — the
+//  runModal call blocks the run loop and hangs the test suite. This file only
+//  verifies that the concrete presenter can be constructed and conforms to the
+//  protocol. The three modal paths (sameAsSource, duplicateDestination,
+//  sourceTagConflict) are verified manually after merge per the manual test plan
+//  in .planning/design/backup-manager-destination-forwarding.md §Manual test plan.
+//
+
+import XCTest
+@testable import ImageIntact
+
+@MainActor
+final class DestinationAlertPresenterTests: XCTestCase {
+
+    /// Smoke test — NSAlertDestinationPresenter can be constructed and conforms
+    /// to DestinationAlertPresenting. Both types don't exist yet; compile failure
+    /// here is the red-phase signal.
+    func testNSAlertDestinationPresenter_canBeConstructed() {
+        let presenter: DestinationAlertPresenting = NSAlertDestinationPresenter()
+        _ = presenter  // suppress unused-variable warning
+    }
+}

--- a/ImageIntactTests/Mocks/MockDestinationAlertPresenter.swift
+++ b/ImageIntactTests/Mocks/MockDestinationAlertPresenter.swift
@@ -1,0 +1,43 @@
+//
+//  MockDestinationAlertPresenter.swift
+//  ImageIntactTests
+//
+//  Mock implementation of DestinationAlertPresenting for testing
+//  BackupManager.setDestination error paths.
+//
+
+import Foundation
+@testable import ImageIntact
+
+/// Test double for DestinationAlertPresenting. Records all calls and returns
+/// configurable values so tests can assert on which alert path fired without
+/// triggering real NSAlert modals.
+@MainActor
+final class MockDestinationAlertPresenter: DestinationAlertPresenting {
+
+    // MARK: - Call-count tracking
+
+    var presentSameAsSourceAlertCallCount = 0
+    var presentDuplicateDestinationAlertCalls: [Int] = []  // captured existingIndex values
+    var presentSourceTagConflictAlertCallCount = 0
+
+    // MARK: - Configurable return values
+
+    /// Controls what presentSourceTagConflictAlert() returns. Default true = "Use This Folder".
+    var sourceTagConflictReturnValue = true
+
+    // MARK: - DestinationAlertPresenting
+
+    func presentSameAsSourceAlert() {
+        presentSameAsSourceAlertCallCount += 1
+    }
+
+    func presentDuplicateDestinationAlert(existingIndex: Int) {
+        presentDuplicateDestinationAlertCalls.append(existingIndex)
+    }
+
+    func presentSourceTagConflictAlert() -> Bool {
+        presentSourceTagConflictAlertCallCount += 1
+        return sourceTagConflictReturnValue
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DestinationAlertPresenting` protocol with three methods (`presentSameAsSourceAlert`, `presentDuplicateDestinationAlert(existingIndex:)`, `presentSourceTagConflictAlert() -> Bool`) and an `NSAlertDestinationPresenter` implementation in `ImageIntact/Models/DestinationAlertPresenter.swift`.
- Inject the presenter into `BackupManager` via an optional init param (default = real `NSAlertDestinationPresenter()`), matching the existing dependency-injection pattern.
- Trim `BackupManager.setDestination`: each catch arm is now a 1-line presenter dispatch. All 3 `if !BackupManager.isRunningTests` guards inside `setDestination` are removed — test/prod divergence moves to DI, addressing the High flag from PR #117 panel review.
- `BackupManager.swift`: 716 → 694 lines (-22).

## Behavior preservation
- Alert text, styles, and button labels match the prior inline NSAlert code verbatim.
- `sourceTagConflict`'s "Use This Folder" still triggers source-tag removal and a setDestination retry.
- `addDestination`, `clearDestination`, `removeDestination` (1-line forwarders) untouched — out of scope per design doc.
- The 3 NSAlerts in `runBackup` are AMUX-15's surface, not AMUX-19's — also untouched.

## Tests
- 7 new cases (6 `BackupManagerSetDestinationTests` + 1 `DestinationAlertPresenterTests` smoke).
- Run under `-testPlan Fast` (workaround for the pre-existing default-test-plan loading bug).
- All pass. Pre-existing failures (10 cases in `ManifestBuilderFilterTests` + `SubdirectoryTraversalTests`) confirmed unrelated.

## Panel review
- 1 round. 1 Blocker / 6 High findings — all pre-existing, pointing at `runBackup`/`cancelOperation`/`cleanupMemory` (AMUX-15's surface). Architecture explicitly notes the `DestinationAlertPresenting` protocol already exists and asks for the same treatment in `runBackup` — that is AMUX-15's job. One Low finding does land on AMUX-19's surface: the `setDestination` catch-all doesn't show a user-facing alert for unexpected errors. Noted and deferred to follow-up (Low, non-blocking).

## Refs
AMUX-19, Refs #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)