### PR TITLE
refactor: extract runBackup alert presentation + fix cancel/cleanup races (#103)

### DIFF
--- a/ImageIntact/Models/BackupAlertPresenter.swift
+++ b/ImageIntact/Models/BackupAlertPresenter.swift
@@ -102,11 +102,10 @@ struct NSAlertBackupPresenter: BackupAlertPresenting {
             message += "📊 Files to backup:\n"
             if filteredSummary.willCopy != filteredSummary.total {
                 message += "   \(filteredSummary.willCopy) of \(filteredSummary.total) files (filtered)\n"
-                message += "   Types: \(filteredSummary.summary)\n\n"
             } else {
                 message += "   \(filteredSummary.total) files\n"
-                message += "   Types: \(filteredSummary.summary)\n\n"
             }
+            message += "   Types: \(filteredSummary.summary)\n\n"
         } else if summary.totalFiles > 0, let fileTypeSummary = summary.fileTypeSummary {
             message += "📊 Files to backup: \(summary.totalFiles)\n"
             message += "   Types: \(fileTypeSummary)\n\n"

--- a/ImageIntact/Models/BackupAlertPresenter.swift
+++ b/ImageIntact/Models/BackupAlertPresenter.swift
@@ -1,0 +1,162 @@
+//
+//  BackupAlertPresenter.swift
+//  ImageIntact
+//
+//  Protocol, data-transfer struct, and AppKit implementation for presenting
+//  BackupManager.runBackup preflight alerts.
+//  Extracted from BackupManager.runBackup (AMUX-15, GH #103) to remove
+//  NSAlert calls from the model layer and enable dependency injection in tests.
+//
+//  Design doc: .planning/design/backup-manager-run-backup-extraction.md
+//
+
+import AppKit
+import Foundation
+
+// MARK: - PreflightSummary
+
+/// Snapshot of the BackupManager state needed to render the preflight summary
+/// alert. Passed into the presenter so the presenter stays a pure UI adapter
+/// and BackupManager owns the data assembly.
+struct PreflightSummary {
+    let sourceName: String
+    let sourcePath: String
+    /// nil when no file-type filter active; otherwise the formatted summary.
+    let filteredSummary: (summary: String, willCopy: Int, total: Int)?
+    /// Formatted file-type summary string (used when no filter is active). nil otherwise.
+    let fileTypeSummary: String?
+    /// Total file count for the non-filtered path. 0 when filter is active.
+    let totalFiles: Int
+    /// Source total bytes; 0 to omit the size line.
+    let totalBytes: Int64
+    /// Destinations as (displayName, deviceName?) tuples.
+    let destinations: [(name: String, deviceName: String?)]
+    let excludeCacheFiles: Bool
+    let skipHiddenFiles: Bool
+    let fileTypeFilterActive: Bool
+}
+
+// MARK: - Protocol
+
+/// Presents user-facing alerts for `BackupManager.runBackup` preflight.
+/// Injected as a dependency so tests can substitute a mock and the model
+/// layer stays free of AppKit calls.
+@MainActor
+protocol BackupAlertPresenting {
+    /// "Insufficient Disk Space" critical alert. No user response needed (the
+    /// backup aborts regardless).
+    func presentInsufficientSpaceAlert(errors: [String])
+
+    /// "Low Disk Space Warning" alert. Returns whether the caller should
+    /// proceed with the backup. `true` = user clicked "Continue".
+    func presentLowSpaceWarning(warnings: [String]) -> Bool
+
+    /// "Backup Summary" preflight alert with a suppression checkbox.
+    /// Returns `(proceed, showAgain)`:
+    /// - `proceed`: `true` = user clicked "Start Backup".
+    /// - `showAgain`: state of the suppression checkbox after the user
+    ///   dismissed the alert. Caller writes this back to the preference.
+    func presentPreflightSummary(_ summary: PreflightSummary) -> (proceed: Bool, showAgain: Bool)
+}
+
+// MARK: - NSAlert implementation
+
+@MainActor
+struct NSAlertBackupPresenter: BackupAlertPresenting {
+
+    func presentInsufficientSpaceAlert(errors: [String]) {
+        let alert = NSAlert()
+        alert.messageText = "Insufficient Disk Space"
+        alert.informativeText = errors.joined(separator: "\n\n")
+        alert.alertStyle = .critical
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    func presentLowSpaceWarning(warnings: [String]) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Low Disk Space Warning"
+        alert.informativeText = warnings.joined(separator: "\n\n") + "\n\nDo you want to continue?"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Continue")
+        alert.addButton(withTitle: "Cancel")
+
+        let response = alert.runModal()
+        return response == .alertFirstButtonReturn
+    }
+
+    func presentPreflightSummary(_ summary: PreflightSummary) -> (proceed: Bool, showAgain: Bool) {
+        let alert = NSAlert()
+        alert.messageText = "Backup Summary"
+
+        // Build the summary message — mirrors the inline construction
+        // previously in BackupManager.runBackup (lines 438-497 before AMUX-15).
+        var message = "Ready to start backup:\n\n"
+
+        // Source info
+        message += "📁 Source: \(summary.sourceName)\n"
+        message += "   Path: \(summary.sourcePath)\n\n"
+
+        // File summary
+        if let filteredSummary = summary.filteredSummary {
+            message += "📊 Files to backup:\n"
+            if filteredSummary.willCopy != filteredSummary.total {
+                message += "   \(filteredSummary.willCopy) of \(filteredSummary.total) files (filtered)\n"
+                message += "   Types: \(filteredSummary.summary)\n\n"
+            } else {
+                message += "   \(filteredSummary.total) files\n"
+                message += "   Types: \(filteredSummary.summary)\n\n"
+            }
+        } else if summary.totalFiles > 0, let fileTypeSummary = summary.fileTypeSummary {
+            message += "📊 Files to backup: \(summary.totalFiles)\n"
+            message += "   Types: \(fileTypeSummary)\n\n"
+        }
+
+        // Size info
+        if summary.totalBytes > 0 {
+            let formatter = ByteCountFormatter()
+            formatter.countStyle = .file
+            let sizeString = formatter.string(fromByteCount: summary.totalBytes)
+            message += "💾 Total size: \(sizeString)\n\n"
+        }
+
+        // Destination info
+        message += "📍 Destination\(summary.destinations.count > 1 ? "s" : ""):\n"
+        for (index, dest) in summary.destinations.enumerated() {
+            message += "   \(index + 1). \(dest.name)"
+            if let deviceName = dest.deviceName, !deviceName.isEmpty {
+                message += " (\(deviceName))"
+            }
+            message += "\n"
+        }
+
+        // Settings info
+        message += "\n⚙️ Settings:\n"
+        if summary.excludeCacheFiles {
+            message += "   • Cache files will be excluded\n"
+        }
+        if summary.skipHiddenFiles {
+            message += "   • Hidden files will be skipped\n"
+        }
+        if summary.fileTypeFilterActive {
+            message += "   • File type filter is active\n"
+        }
+
+        alert.informativeText = message
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Start Backup")
+        alert.addButton(withTitle: "Cancel")
+
+        // Add "Show this summary before run" checkbox (on by default)
+        alert.showsSuppressionButton = true
+        alert.suppressionButton?.title = "Show this summary before run"
+        alert.suppressionButton?.state = .on
+
+        let response = alert.runModal()
+
+        return (
+            proceed: response == .alertFirstButtonReturn,
+            showAgain: alert.suppressionButton?.state == .on
+        )
+    }
+}

--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -435,8 +435,8 @@ class BackupManager {
         if PreferencesManager.shared.showPreflightSummary {
             let summary = buildPreflightSummary(source: source, destinations: destinations)
             let (proceed, showAgain) = backupAlertPresenter.presentPreflightSummary(summary)
-            PreferencesManager.shared.showPreflightSummary = showAgain
             guard proceed else { return }
+            PreferencesManager.shared.showPreflightSummary = showAgain
         }
 
         // State setup — reset everything cleanupMemory's deferred task would have
@@ -479,16 +479,17 @@ class BackupManager {
         let nonFilteredTypeSummary: String? = sourceFileTypes.isEmpty ? nil : getFormattedFileTypeSummary()
 
         // Build destination tuples with optional drive device names.
-        var destTuples: [(name: String, deviceName: String?)] = []
-        for (index, dest) in destinations.enumerated() {
-            var deviceName: String? = nil
-            if index < destinationItems.count {
-                let itemID = destinationItems[index].id
-                if let driveInfo = destinationDriveInfo[itemID], !driveInfo.deviceName.isEmpty {
-                    deviceName = driveInfo.deviceName
-                }
-            }
-            destTuples.append((name: dest.lastPathComponent, deviceName: deviceName))
+        // Zip the raw parallel arrays before filtering nils so indices stay aligned:
+        // compactMap on destinationURLs alone would shift the index into
+        // destinationItems if any earlier slot is nil.
+        let validPairs: [(URL, DestinationItem)] = zip(destinationURLs, destinationItems).compactMap { url, item in
+            guard let url = url else { return nil }
+            return (url, item)
+        }
+        let destTuples: [(name: String, deviceName: String?)] = validPairs.map { url, item in
+            let deviceName = destinationDriveInfo[item.id]?.deviceName
+            let resolvedDeviceName = (deviceName?.isEmpty == false) ? deviceName : nil
+            return (name: url.lastPathComponent, deviceName: resolvedDeviceName)
         }
 
         return PreflightSummary(

--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -186,6 +186,9 @@ class BackupManager {
     var duplicateAnalyses: [URL: DuplicateDetector.DuplicateAnalysis]?
     let duplicateDetector: DuplicateDetectorProtocol
     let destinationAlertPresenter: DestinationAlertPresenting
+    let backupAlertPresenter: BackupAlertPresenting
+    private let deferredCleanupDelayNanos: UInt64
+    internal var deferredCleanupTask: Task<Void, Never>?
     var skipExactDuplicates = true
     var skipRenamedDuplicates = false
 
@@ -230,7 +233,9 @@ class BackupManager {
         driveAnalyzer: DriveAnalyzerProtocol? = nil,
         diskSpaceChecker: DiskSpaceProtocol? = nil,
         duplicateDetector: DuplicateDetectorProtocol? = nil,
-        destinationAlertPresenter: DestinationAlertPresenting? = nil
+        destinationAlertPresenter: DestinationAlertPresenting? = nil,
+        backupAlertPresenter: BackupAlertPresenting? = nil,
+        deferredCleanupDelayNanos: UInt64 = 10_000_000_000
     ) {
         // Use provided dependencies or create real implementations
         let resolvedFileOps = fileOperations ?? DefaultFileOperations()
@@ -242,6 +247,8 @@ class BackupManager {
         self.diskSpaceChecker = resolvedDiskSpace
         self.duplicateDetector = duplicateDetector ?? DuplicateDetector()
         self.destinationAlertPresenter = destinationAlertPresenter ?? NSAlertDestinationPresenter()
+        self.backupAlertPresenter = backupAlertPresenter ?? NSAlertBackupPresenter()
+        self.deferredCleanupDelayNanos = deferredCleanupDelayNanos
 
         // Create delegated managers
         self.sourceManager = SourceManager(fileOperations: resolvedFileOps)
@@ -251,9 +258,10 @@ class BackupManager {
             diskSpaceChecker: resolvedDiskSpace
         )
 
-        // Initialize organization name from last used (if user previously customized)
+        // Initialize organization name from last used (if user previously customized).
+        // Wrap in SmartFolderName.sanitize because didSet doesn't fire during init.
         if let lastUsedName = PreferencesManager.shared.lastUsedOrganizationFolderName {
-            organizationName = lastUsedName
+            organizationName = SmartFolderName.sanitize(lastUsedName)
         }
 
         // Check for UI test mode
@@ -389,6 +397,12 @@ class BackupManager {
     }
 
     func runBackup() {
+        // Low fix: isProcessing guard — prevent re-entrant runBackup.
+        guard !isProcessing else {
+            logWarning("runBackup called while already processing — ignoring")
+            return
+        }
+
         guard let source = sourceURL else {
             logWarning("Missing source folder.")
             return
@@ -396,134 +410,44 @@ class BackupManager {
 
         let destinations = destinationURLs.compactMap { $0 }
 
-        // Check disk space for all destinations
+        // Check disk space for all destinations.
+        // High fix: use sourceTotalBytes (set at scan time) not totalBytesToCopy
+        // (a progress var that is 0 or stale before the orchestrator runs).
         let spaceChecks = diskSpaceChecker.checkAllDestinations(
             destinations: destinations,
-            requiredBytes: totalBytesToCopy
+            requiredBytes: sourceTotalBytes
         )
 
         let (canProceed, warnings, errors) = diskSpaceChecker.evaluateSpaceChecks(spaceChecks)
 
-        // If we have errors (insufficient space), show alert and abort
+        // Insufficient space: show alert and abort.
         if !canProceed {
-            let alert = NSAlert()
-            alert.messageText = "Insufficient Disk Space"
-            alert.informativeText = errors.joined(separator: "\n\n")
-            alert.alertStyle = .critical
-            alert.addButton(withTitle: "OK")
-            alert.runModal()
+            backupAlertPresenter.presentInsufficientSpaceAlert(errors: errors)
             return
         }
 
-        // If we have warnings (< 10% free after backup), show alert with option to proceed
+        // Low space warning: let user decide whether to proceed.
         if !warnings.isEmpty {
-            let alert = NSAlert()
-            alert.messageText = "Low Disk Space Warning"
-            alert.informativeText = warnings.joined(separator: "\n\n") + "\n\nDo you want to continue?"
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "Continue")
-            alert.addButton(withTitle: "Cancel")
-
-            let response = alert.runModal()
-            if response != .alertFirstButtonReturn {
-                return
-            }
+            guard backupAlertPresenter.presentLowSpaceWarning(warnings: warnings) else { return }
         }
 
-        // Show pre-flight summary if enabled
+        // Pre-flight summary (if enabled).
         if PreferencesManager.shared.showPreflightSummary {
-            let alert = NSAlert()
-            alert.messageText = "Backup Summary"
-
-            // Build the summary message
-            var message = "Ready to start backup:\n\n"
-
-            // Source info
-            message += "📁 Source: \(source.lastPathComponent)\n"
-            message += "   Path: \(source.path)\n\n"
-
-            // File summary
-            if let filteredSummary = getFilteredFilesSummary() {
-                message += "📊 Files to backup:\n"
-                if filteredSummary.willCopy != filteredSummary.total {
-                    message += "   \(filteredSummary.willCopy) of \(filteredSummary.total) files (filtered)\n"
-                    message += "   Types: \(filteredSummary.summary)\n\n"
-                } else {
-                    message += "   \(filteredSummary.total) files\n"
-                    message += "   Types: \(filteredSummary.summary)\n\n"
-                }
-            } else if !sourceFileTypes.isEmpty {
-                let totalFiles = sourceFileTypes.values.reduce(0, +)
-                message += "📊 Files to backup: \(totalFiles)\n"
-                message += "   Types: \(getFormattedFileTypeSummary())\n\n"
-            }
-
-            // Size info
-            if sourceTotalBytes > 0 {
-                let formatter = ByteCountFormatter()
-                formatter.countStyle = .file
-                let sizeString = formatter.string(fromByteCount: sourceTotalBytes)
-                message += "💾 Total size: \(sizeString)\n\n"
-            }
-
-            // Destination info
-            message += "📍 Destination\(destinations.count > 1 ? "s" : ""):\n"
-            for (index, dest) in destinations.enumerated() {
-                message += "   \(index + 1). \(dest.lastPathComponent)"
-
-                // Add drive info if available
-                if index < destinationItems.count {
-                    let itemID = destinationItems[index].id
-                    if let driveInfo = destinationDriveInfo[itemID] {
-                        if !driveInfo.deviceName.isEmpty {
-                            message += " (\(driveInfo.deviceName))"
-                        }
-                    }
-                }
-                message += "\n"
-            }
-
-            // Settings info
-            message += "\n⚙️ Settings:\n"
-            if PreferencesManager.shared.excludeCacheFiles {
-                message += "   • Cache files will be excluded\n"
-            }
-            if PreferencesManager.shared.skipHiddenFiles {
-                message += "   • Hidden files will be skipped\n"
-            }
-            if !fileTypeFilter.includedExtensions.isEmpty {
-                message += "   • File type filter is active\n"
-            }
-
-            alert.informativeText = message
-            alert.alertStyle = .informational
-            alert.addButton(withTitle: "Start Backup")
-            alert.addButton(withTitle: "Cancel")
-
-            // Add "Show this summary before run" checkbox
-            alert.showsSuppressionButton = true
-            alert.suppressionButton?.title = "Show this summary before run"
-            alert.suppressionButton?.state = .on // Checked by default
-
-            let response = alert.runModal()
-
-            // Update preference based on checkbox state
-            // Note: suppression button logic is inverted - when unchecked, we disable the summary
-            PreferencesManager.shared.showPreflightSummary = (alert.suppressionButton?.state == .on)
-
-            if response != .alertFirstButtonReturn {
-                return
-            }
+            let summary = buildPreflightSummary(source: source, destinations: destinations)
+            let (proceed, showAgain) = backupAlertPresenter.presentPreflightSummary(summary)
+            PreferencesManager.shared.showPreflightSummary = showAgain
+            guard proceed else { return }
         }
 
+        // State setup — reset everything cleanupMemory's deferred task would have
+        // cleared so we don't depend on its timing (High fix: state leak on rapid restart).
         isProcessing = true
         statusMessage = "Preparing backup..."
-        progressTracker.totalFiles = 0
-        progressTracker.processedFiles = 0
-        progressTracker.currentFile = ""
         failedFiles = []
-        sessionID = UUID().uuidString
+        statistics.reset()
+        progressTracker.resetAll()
         logEntries = []
+        sessionID = UUID().uuidString
         shouldCancel = false
         debugLog = []
 
@@ -543,13 +467,55 @@ class BackupManager {
         }
     }
 
+    /// Build the data snapshot the preflight presenter needs.
+    /// Pure data construction — no UI. Pulled out so runBackup is easy to read
+    /// and the summary construction is testable in isolation.
+    private func buildPreflightSummary(source: URL, destinations: [URL]) -> PreflightSummary {
+        // Filtered summary (when a file-type filter is active).
+        let filteredSummary = getFilteredFilesSummary()
+
+        // Non-filtered file count and type summary (used when no filter is active).
+        let nonFilteredTotalFiles = sourceFileTypes.values.reduce(0, +)
+        let nonFilteredTypeSummary: String? = sourceFileTypes.isEmpty ? nil : getFormattedFileTypeSummary()
+
+        // Build destination tuples with optional drive device names.
+        var destTuples: [(name: String, deviceName: String?)] = []
+        for (index, dest) in destinations.enumerated() {
+            var deviceName: String? = nil
+            if index < destinationItems.count {
+                let itemID = destinationItems[index].id
+                if let driveInfo = destinationDriveInfo[itemID], !driveInfo.deviceName.isEmpty {
+                    deviceName = driveInfo.deviceName
+                }
+            }
+            destTuples.append((name: dest.lastPathComponent, deviceName: deviceName))
+        }
+
+        return PreflightSummary(
+            sourceName: source.lastPathComponent,
+            sourcePath: source.path,
+            filteredSummary: filteredSummary,
+            fileTypeSummary: nonFilteredTypeSummary,
+            totalFiles: nonFilteredTotalFiles,
+            totalBytes: sourceTotalBytes,
+            destinations: destTuples,
+            excludeCacheFiles: PreferencesManager.shared.excludeCacheFiles,
+            skipHiddenFiles: PreferencesManager.shared.skipHiddenFiles,
+            fileTypeFilterActive: !fileTypeFilter.includedExtensions.isEmpty
+        )
+    }
+
     func cancelOperation() {
         guard !shouldCancel else { return } // Prevent multiple cancellations
+
+        // Local strong ref keeps orchestrator alive through end of this function
+        // even after cleanupMemory nils currentOrchestrator. (Medium fix: deallocation race)
+        let orchestratorRef = currentOrchestrator
         shouldCancel = true
         statusMessage = "Cancelling backup..."
 
-        // Clean up any pending large backup confirmation
-        // This resumes the continuation with false to unblock the waiting backup
+        // Clean up any pending large backup confirmation.
+        // Resumes the continuation with false to unblock the waiting backup.
         if let continuation = largeBackupContinuation {
             ApplicationLogger.shared.warning("Cleaning up pending large backup continuation due to cancellation", category: .backup)
             continuation.resume(returning: false)
@@ -558,50 +524,39 @@ class BackupManager {
             largeBackupInfo = nil
         }
 
-        // Immediately clear all progress indicators
-        Task { @MainActor [weak self] in
-            guard let self = self else { return }
-
-            // Force clear all destination progress immediately
-            for name in self.progressTracker.destinationProgress.keys {
-                self.progressTracker.setDestinationProgress(0, for: name)
-                self.progressTracker.setDestinationState("cancelled", for: name)
-            }
-
-            // Clear file name displays
-            self.currentFileName = ""
-            self.currentDestinationName = ""
-            self.overallStatusText = "" // Clear this so UI doesn't show "1 destination copying"
-
-            // Force UI update
-            self.isProcessing = false
-            self.currentPhase = .idle
-            self.statusMessage = "Backup cancelled"
-
-            // Clear progress tracker immediately - this resets all the computed values
-            self.progressTracker.resetAll()
-
-            // Stop sleep prevention
-            SleepPrevention.shared.stopPreventingSleep()
+        // Synchronous immediate state clear (was inside a Task; the deferral broke the
+        // new `guard !isProcessing` in runBackup on rapid cancel→backup). (Medium fix)
+        for name in progressTracker.destinationProgress.keys {
+            progressTracker.setDestinationProgress(0, for: name)
+            progressTracker.setDestinationState("cancelled", for: name)
         }
+        currentFileName = ""
+        currentDestinationName = ""
+        overallStatusText = ""
+        currentPhase = .idle
+        statusMessage = "Backup cancelled"
+        progressTracker.resetAll()
+        SleepPrevention.shared.stopPreventingSleep()
 
-        // Cancel orchestrator
-        Task { @MainActor [weak self] in
-            self?.currentOrchestrator?.cancel()
-        }
+        // Blocker fix: cancel synchronously against retained ref BEFORE cleanupMemory
+        // nils currentOrchestrator. Previously this was in a Task — cancel never reached
+        // the orchestrator because cleanupMemory ran first and nil'd the reference.
+        orchestratorRef?.cancel()
 
-        // Clean up resources
+        // Flip the gating flag AFTER orchestrator cancel propagates. (Medium fix: ordering)
+        isProcessing = false
+
+        // Resource cleanup can stay async — not on the rapid-restart path.
         Task { [weak self] in
             await self?.resourceManager.cleanup()
         }
 
-        // Force memory cleanup
         cleanupMemory()
     }
 
-    /// Force memory cleanup after backup completion or cancellation
+    /// Force memory cleanup after backup completion or cancellation.
     func cleanupMemory() {
-        // Clear large data structures
+        // Immediate cleanup — clear large data structures.
         logEntries.removeAll(keepingCapacity: false)
         debugLog.removeAll(keepingCapacity: false)
 
@@ -610,30 +565,29 @@ class BackupManager {
         // DON'T clear progress data yet - UI may still need it
         // DON'T clear sourceFileTypes - needed for UI display
 
-        // Note: We keep sourceFileTypes since it's needed for the UI
-        // It will be refreshed when a new source is selected
-
-        // Don't clear destination info - keep it for UI display
-        // destinationDriveInfo.removeAll(keepingCapacity: false)
-
-        // Clear orchestrator reference
+        // Clear orchestrator reference.
         currentOrchestrator = nil
 
-        // Note: Core Data will manage its own memory
+        // Note: Core Data will manage its own memory.
         EventLogger.shared.resetContexts()
 
-        // Force cleanup with autorelease pool
-        autoreleasepool {}
+        // Low fix: removed two empty autoreleasepool {} calls (drained nothing).
 
         logInfo("Initial memory cleanup completed", category: .performance)
 
-        // Schedule deep cleanup after UI has shown stats
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 10_000_000_000) // 10 seconds
-
+        // High fix: cancel any prior deferred task; capture session id; bail on mismatch.
+        // Prevents a prior backup's deferred cleanup from wiping a new backup's state.
+        deferredCleanupTask?.cancel()
+        let capturedSessionID = sessionID
+        deferredCleanupTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .nanoseconds(Int(self?.deferredCleanupDelayNanos ?? 10_000_000_000)))
+            guard !Task.isCancelled else { return }
             guard let self = self else { return }
+            guard self.sessionID == capturedSessionID else {
+                logInfo("Deferred cleanup bailed: session changed", category: .performance)
+                return
+            }
 
-            // Now clear the rest
             self.failedFiles.removeAll(keepingCapacity: false)
             self.progressTracker.resetAll()
             self.progressTracker.destinationProgress.removeAll(keepingCapacity: false)
@@ -643,10 +597,7 @@ class BackupManager {
             self.overallStatusText = ""
             // Keep scanProgress - it shows the file type summary
 
-            // Clean up checksum buffer pool
             ChecksumBufferPool.shared.cleanupUnusedBuffers()
-
-            autoreleasepool {}
             logInfo("Deep memory cleanup completed", category: .performance)
         }
     }

--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -580,8 +580,12 @@ class BackupManager {
         // Prevents a prior backup's deferred cleanup from wiping a new backup's state.
         deferredCleanupTask?.cancel()
         let capturedSessionID = sessionID
+        let capturedDelayNanos = deferredCleanupDelayNanos
         deferredCleanupTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .nanoseconds(Int(self?.deferredCleanupDelayNanos ?? 10_000_000_000)))
+            // Bail early if self is already gone — no point sleeping for 10s
+            // just to do nothing on wake (would leave a zombie task in the pool).
+            guard self != nil else { return }
+            try? await Task.sleep(for: .nanoseconds(Int(capturedDelayNanos)))
             guard !Task.isCancelled else { return }
             guard let self = self else { return }
             guard self.sessionID == capturedSessionID else {

--- a/ImageIntact/Models/Protocols/DiskSpaceProtocol.swift
+++ b/ImageIntact/Models/Protocols/DiskSpaceProtocol.swift
@@ -65,6 +65,12 @@ final class MockDiskSpaceChecker: DiskSpaceProtocol {
   var checkCallCount = 0
   var evaluationResult: (canProceed: Bool, warnings: [String], errors: [String]) = (true, [], [])
 
+  /// Captures the most recent `requiredBytes` value passed to
+  /// `checkAllDestinations` so tests can assert on the value (e.g.
+  /// verifying the disk-space gate uses `sourceTotalBytes` rather than
+  /// the historically-buggy `totalBytesToCopy`).
+  var lastRequiredBytes: Int64?
+
   func checkDestinationSpace(
     destination: URL, requiredBytes: Int64, additionalBuffer: Int64 = 100_000_000
   ) -> DiskSpaceChecker.SpaceCheckResult {
@@ -127,6 +133,7 @@ final class MockDiskSpaceChecker: DiskSpaceProtocol {
   func checkAllDestinations(destinations: [URL], requiredBytes: Int64) -> [DiskSpaceChecker
     .SpaceCheckResult]
   {
+    lastRequiredBytes = requiredBytes
     return destinations.map { destination in
       checkDestinationSpace(destination: destination, requiredBytes: requiredBytes)
     }

--- a/ImageIntactTests/BackupAlertPresenterTests.swift
+++ b/ImageIntactTests/BackupAlertPresenterTests.swift
@@ -1,0 +1,63 @@
+//
+//  BackupAlertPresenterTests.swift
+//  ImageIntactTests
+//
+//  Tests for NSAlertBackupPresenter (AMUX-15).
+//
+//  NOTE: Modal presentation (NSAlert.runModal) cannot be tested in XCTest — the
+//  runModal call blocks the run loop and hangs the test suite. This file only
+//  verifies that the concrete presenter can be constructed and conforms to the
+//  protocol. The three modal paths are verified manually after merge per the
+//  manual test plan below.
+//
+//  NSAlertBackupPresenter and BackupAlertPresenting don't exist yet.
+//  Compile failure here IS the red-phase signal.
+//
+//  Design doc: .planning/design/backup-manager-run-backup-extraction.md
+//
+
+import XCTest
+@testable import ImageIntact
+
+@MainActor
+final class BackupAlertPresenterTests: XCTestCase {
+
+    /// Smoke test — NSAlertBackupPresenter can be constructed and assigned to
+    /// the BackupAlertPresenting protocol type.
+    func testNSAlertBackupPresenter_canBeConstructed() {
+        let presenter: BackupAlertPresenting = NSAlertBackupPresenter()
+        _ = presenter  // suppress unused-variable warning
+    }
+}
+
+// MARK: - Manual test plan (post-merge, in the real app)
+//
+// 1. Insufficient space path:
+//    - Set source to a folder whose size exceeds destination free space.
+//    - Click "Run Backup".
+//    - Expect: "Insufficient Disk Space" critical alert shows error messages.
+//    - Click "OK" → backup does NOT start; isProcessing stays false.
+//
+// 2. Low disk space warning:
+//    - Set source close to (but within) destination free space; ensure <10% free after backup.
+//    - Click "Run Backup".
+//    - Expect: "Low Disk Space Warning" alert with warnings + "Do you want to continue?".
+//    - Click "Cancel" → backup does NOT start.
+//    - Repeat, click "Continue" → preflight (if enabled) → backup starts.
+//
+// 3. Preflight summary (showPreflightSummary = true):
+//    - Enable "Show backup summary before run" in Preferences.
+//    - Click "Run Backup" with plenty of disk space.
+//    - Expect: "Backup Summary" alert showing source, file count, size, destinations, settings.
+//    - Uncheck "Show this summary before run", click "Start Backup".
+//    - Expect: backup starts; next "Run Backup" skips preflight (preference written back).
+//    - Repeat with checkbox on, click "Cancel" → backup does NOT start.
+//
+// 4. Cancel race fix (deferred cleanup):
+//    - Start a backup, cancel it, immediately start a new backup within 10 seconds.
+//    - Expect: the new backup's failedFiles/progressTracker/statistics are NOT wiped ~10s in.
+//
+// 5. Orchestrator cancel fix:
+//    - Start a backup, cancel it.
+//    - Expect: backup actually stops (no further file copy progress).
+//    - Status shows "Backup cancelled" and isProcessing becomes false.

--- a/ImageIntactTests/BackupManagerCancelTests.swift
+++ b/ImageIntactTests/BackupManagerCancelTests.swift
@@ -1,0 +1,135 @@
+//
+//  BackupManagerCancelTests.swift
+//  ImageIntactTests
+//
+//  TDD red-phase tests for BackupManager.cancelOperation bug fixes (AMUX-15).
+//
+//  These tests reference MockBackupOrchestrator (which wraps the new subclass approach)
+//  and the new synchronous isProcessing-clear behavior. Compile failure on symbols
+//  that don't yet exist IS the red-phase signal.
+//
+//  Design doc: .planning/design/backup-manager-run-backup-extraction.md §"Fixed cancelOperation"
+//
+
+import XCTest
+@testable import ImageIntact
+
+@MainActor
+final class BackupManagerCancelTests: BaseBackupManagerTestCase {
+
+    // MARK: - Test fixtures
+
+    var mockFileOps: MockFileOperations!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // Clear preferences state (bookmarks already cleared by base class).
+        PreferencesManager.shared.resetToDefaults()
+
+        mockFileOps = MockFileOperations()
+        bm = BackupManager(fileOperations: mockFileOps)
+    }
+
+    override func tearDown() async throws {
+        PreferencesManager.shared.resetToDefaults()
+
+        mockFileOps = nil
+
+        // Base class cancels any in-flight backup (reads self.bm before releasing it)
+        // and restores bookmarks. bm is released naturally when the test instance deinits.
+        try await super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    /// Blocker fix verification: orchestrator.cancel() must be called SYNCHRONOUSLY
+    /// (before cleanupMemory nils currentOrchestrator). With the buggy code, the
+    /// cancel was scheduled in a Task — this test asserts the count without any
+    /// Task.yield, so it would be 0 with the old code.
+    func testCancelOperation_cancelsOrchestratorBeforeNil() {
+        let mockOrch = MockBackupOrchestrator(
+            progressTracker: ProgressTracker(),
+            resourceManager: ResourceManager()
+        )
+        bm.currentOrchestrator = mockOrch
+        bm.isProcessing = true
+
+        bm.cancelOperation()
+
+        // Synchronous assertion — no yield, no wait.
+        XCTAssertEqual(mockOrch.cancelCallCount, 1,
+                       "orchestrator.cancel() must be called synchronously before cleanupMemory nils it")
+    }
+
+    /// shouldCancel guard: second cancelOperation call is ignored.
+    func testCancelOperation_doubleCallIgnored() {
+        let mockOrch = MockBackupOrchestrator(
+            progressTracker: ProgressTracker(),
+            resourceManager: ResourceManager()
+        )
+        bm.currentOrchestrator = mockOrch
+        bm.isProcessing = true
+
+        bm.cancelOperation()
+        bm.cancelOperation()
+
+        XCTAssertEqual(mockOrch.cancelCallCount, 1,
+                       "Second cancelOperation call must be ignored by shouldCancel guard")
+    }
+
+    /// Medium fix verification: isProcessing must be cleared SYNCHRONOUSLY, not inside
+    /// a Task. With the old code (isProcessing = false inside a Task), this assertion
+    /// would fail because the Task hasn't run yet.
+    func testCancelOperation_isProcessingFalseSynchronously() {
+        bm.isProcessing = true
+
+        bm.cancelOperation()
+
+        // Immediate assertion — no Task.yield, no await.
+        XCTAssertFalse(bm.isProcessing,
+                       "isProcessing must be set to false synchronously in cancelOperation (not inside a Task)")
+    }
+
+    /// Existing behavior preserved: a pending largeBackupContinuation is resumed
+    /// with false and cleared when cancelOperation is called.
+    func testCancelOperation_clearsLargeBackupContinuation() async {
+        // Set up a continuation that we can observe.
+        var continuationResult: Bool? = nil
+
+        // Spawn a task that suspends on a continuation and captures the result.
+        let awaitingTask = Task { @MainActor in
+            await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                bm.largeBackupContinuation = continuation
+                bm.showLargeBackupConfirmation = true
+            }
+        }
+
+        // Poll until the child task sets the continuation, with a 2s timeout.
+        // Task.yield() alone doesn't guarantee the child task advances far enough
+        // to reach the withCheckedContinuation suspension and assign the property.
+        // Without this guard, cancelOperation() could fire before the continuation
+        // is set, do nothing, and then `await awaitingTask.value` hangs forever.
+        let deadline = Date().addingTimeInterval(2.0)
+        while bm.largeBackupContinuation == nil {
+            if Date() > deadline {
+                XCTFail("largeBackupContinuation never got set within 2s")
+                return
+            }
+            await Task.yield()
+        }
+
+        bm.isProcessing = true
+        bm.cancelOperation()
+
+        // Collect the result the continuation was resumed with.
+        continuationResult = await awaitingTask.value
+
+        XCTAssertEqual(continuationResult, false,
+                       "Continuation must be resumed with false on cancellation")
+        XCTAssertNil(bm.largeBackupContinuation,
+                     "largeBackupContinuation must be nil after cancelOperation")
+        XCTAssertFalse(bm.showLargeBackupConfirmation,
+                       "showLargeBackupConfirmation must be false after cancelOperation")
+    }
+}

--- a/ImageIntactTests/BackupManagerCleanupTests.swift
+++ b/ImageIntactTests/BackupManagerCleanupTests.swift
@@ -1,0 +1,151 @@
+//
+//  BackupManagerCleanupTests.swift
+//  ImageIntactTests
+//
+//  TDD red-phase tests for BackupManager.cleanupMemory bug fixes (AMUX-15).
+//
+//  References BackupManager init parameter `deferredCleanupDelayNanos` and the
+//  new internal `deferredCleanupTask` property — neither exist yet.
+//  Compile failure here IS the red-phase signal.
+//
+//  Design doc: .planning/design/backup-manager-run-backup-extraction.md §"Fixed cleanupMemory"
+//
+
+import XCTest
+@testable import ImageIntact
+
+// Note: One of the panel-review fixes for AMUX-15 is the removal of two empty
+// `autoreleasepool {}` blocks from `cleanupMemory`. There is no test for that
+// fix because the change has no observable behavior — empty autoreleasepool
+// blocks drain nothing and removing them is pure dead-code cleanup.
+
+@MainActor
+final class BackupManagerCleanupTests: BaseBackupManagerTestCase {
+
+    // MARK: - Test fixtures
+
+    var mockFileOps: MockFileOperations!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // Clear preferences state (bookmarks already cleared by base class).
+        PreferencesManager.shared.resetToDefaults()
+
+        mockFileOps = MockFileOperations()
+        // Note: bm is not pre-assigned here — each test assigns self.bm with its own
+        // BackupManager (custom deferredCleanupDelayNanos). The base class tearDown will
+        // cancel any in-flight backup via self.bm before releasing it.
+    }
+
+    override func tearDown() async throws {
+        PreferencesManager.shared.resetToDefaults()
+
+        mockFileOps = nil
+
+        // Base class cancels any in-flight backup via self.bm and restores bookmarks.
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Populate failedFiles with a synthetic entry for assertions.
+    private func addFailedFile(to bm: BackupManager) {
+        bm.failedFiles.append((
+            file: "/Volumes/Source/test.jpg",
+            destination: "/Volumes/BackupDrive",
+            error: "test error"
+        ))
+    }
+
+    // MARK: - Tests
+
+    /// High fix verification: deferred cleanup runs after the delay when sessionID
+    /// hasn't changed.
+    func testCleanupMemory_deferredCleanupRunsWhenSessionUnchanged() async throws {
+        // 50ms delay — fast enough for tests, slow enough to test the deferred path.
+        // deferredCleanupDelayNanos doesn't exist yet; compile failure is expected.
+        // Assigned to self.bm so the base class tearDown can cancel any in-flight work.
+        self.bm = BackupManager(
+            fileOperations: mockFileOps,
+            deferredCleanupDelayNanos: 50_000_000  // 50ms
+        )
+
+        bm.sessionID = "test-session-abc"
+        addFailedFile(to: bm)
+        XCTAssertFalse(bm.failedFiles.isEmpty, "Precondition: failedFiles should have an entry")
+
+        bm.cleanupMemory()
+
+        // Synchronous check: failedFiles must NOT be cleared immediately.
+        // Without this assertion, the test would pass even if cleanupMemory()
+        // mistakenly cleared the array synchronously rather than via the deferred task.
+        XCTAssertFalse(bm.failedFiles.isEmpty,
+                       "failedFiles must not be cleared synchronously — only by the deferred task")
+
+        // Poll for up to 2s for the deferred task to clear failedFiles.
+        // Task.sleep(150ms) is not reliable on loaded CI runners; a 150ms window
+        // can easily be exceeded by the scheduler, causing false failures.
+        let deadline = Date().addingTimeInterval(2.0)
+        while !bm.failedFiles.isEmpty {
+            if Date() > deadline {
+                XCTFail("Deferred cleanup didn't run within 2s")
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertTrue(bm.failedFiles.isEmpty,
+                      "failedFiles must be cleared by deferred cleanup when sessionID is unchanged")
+    }
+
+    /// High fix verification: deferred cleanup bails when sessionID changes before the delay.
+    /// This is the core race-condition fix: a new backup's state is protected.
+    func testCleanupMemory_deferredCleanupBailsWhenSessionChanges() async throws {
+        // Assigned to self.bm so the base class tearDown can cancel any in-flight work.
+        self.bm = BackupManager(
+            fileOperations: mockFileOps,
+            deferredCleanupDelayNanos: 50_000_000  // 50ms
+        )
+
+        bm.sessionID = "session-1"
+        addFailedFile(to: bm)
+
+        bm.cleanupMemory()
+
+        // Simulate a new backup starting (sessionID changes) before the delay fires.
+        bm.sessionID = "session-2"
+
+        // Wait 1s — long enough that on a loaded CI runner where thread scheduling
+        // is delayed, the deferred task would still have plenty of time to run if
+        // the sessionID guard weren't working. If it doesn't run by 1s, we have
+        // high confidence the guard bailed.
+        try await Task.sleep(for: .seconds(1))
+
+        XCTAssertFalse(bm.failedFiles.isEmpty,
+                       "failedFiles must NOT be cleared when sessionID changed (deferred task should bail)")
+    }
+
+    /// Design doc §"deferredCleanupTask declared internal": second cleanupMemory call
+    /// cancels the first deferred task. Relies on `deferredCleanupTask` being `internal`.
+    func testCleanupMemory_secondCallCancelsFirstDeferredTask() async {
+        // Use 50ms so the first task is still sleeping when we check isCancelled.
+        // Assigned to self.bm so the base class tearDown can cancel any in-flight work.
+        self.bm = BackupManager(
+            fileOperations: mockFileOps,
+            deferredCleanupDelayNanos: 50_000_000  // 50ms
+        )
+
+        bm.cleanupMemory()
+        let firstTask = bm.deferredCleanupTask  // internal property (doesn't exist yet)
+
+        bm.cleanupMemory()
+
+        // Yield to let Task.cancel() propagate.
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertTrue(firstTask?.isCancelled ?? false,
+                      "The first deferredCleanupTask must be cancelled when cleanupMemory is called again")
+    }
+}

--- a/ImageIntactTests/BackupManagerOrganizationNameInitTests.swift
+++ b/ImageIntactTests/BackupManagerOrganizationNameInitTests.swift
@@ -1,0 +1,77 @@
+//
+//  BackupManagerOrganizationNameInitTests.swift
+//  ImageIntactTests
+//
+//  TDD red-phase tests for the BackupManager init organizationName sanitization fix (AMUX-15).
+//
+//  Low fix: organizationName = lastUsedName at init bypassed SmartFolderName.sanitize
+//  because `didSet` doesn't fire during initialization. The fix wraps the assignment in
+//  SmartFolderName.sanitize() directly.
+//
+//  This test uses real UserDefaults (lastUsedOrganizationFolderName) with save/restore
+//  in setUp/tearDown so it doesn't pollute other tests.
+//
+//  Design doc: .planning/design/backup-manager-run-backup-extraction.md §"Fixed init"
+//
+
+import XCTest
+@testable import ImageIntact
+
+@MainActor
+final class BackupManagerOrganizationNameInitTests: BaseBackupManagerTestCase {
+
+    // MARK: - Test fixtures
+
+    var mockFileOps: MockFileOperations!
+    private var savedLastUsedName: String? = nil
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // Save current value of lastUsedOrganizationFolderName before resetting.
+        savedLastUsedName = PreferencesManager.shared.lastUsedOrganizationFolderName
+
+        // Reset preferences (clears lastUsedOrganizationFolderName; bookmarks already
+        // cleared by base class).
+        PreferencesManager.shared.resetToDefaults()
+
+        mockFileOps = MockFileOperations()
+        // Note: bm is not pre-assigned here — each test assigns self.bm with its own
+        // BackupManager after loading the desired preference state. The base class
+        // tearDown will cancel any in-flight backup via self.bm before releasing it.
+    }
+
+    override func tearDown() async throws {
+        // Restore lastUsedOrganizationFolderName.
+        PreferencesManager.shared.lastUsedOrganizationFolderName = savedLastUsedName
+
+        mockFileOps = nil
+
+        // Base class cancels any in-flight backup via self.bm and restores bookmarks.
+        try await super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    /// Low fix verification: organizationName loaded from preferences at init must be
+    /// sanitized via SmartFolderName.sanitize (the didSet doesn't fire during init).
+    ///
+    /// "foo/bar" → sanitize replaces "/" with "_" → "foo_bar".
+    /// We verify against SmartFolderName.sanitize("foo/bar"), not the literal "foo_bar",
+    /// so the test is robust to future changes in the sanitize implementation.
+    func testInit_organizationNameFromPrefs_isSanitized() {
+        // Write a dirty name to UserDefaults (forward slash triggers sanitization).
+        let dirtyName = "foo/bar"
+        PreferencesManager.shared.lastUsedOrganizationFolderName = dirtyName
+
+        // Construct BackupManager — init reads lastUsedOrganizationFolderName.
+        // Assigned to self.bm for tearDown's benefit (cancellation safeguard).
+        self.bm = BackupManager(fileOperations: mockFileOps)
+
+        let expectedName = SmartFolderName.sanitize(dirtyName)
+        XCTAssertEqual(bm.organizationName, expectedName,
+                       "organizationName must be sanitized at init; got '\(bm.organizationName)' instead of '\(expectedName)'")
+        XCTAssertNotEqual(bm.organizationName, dirtyName,
+                          "organizationName must not equal the raw unsanitized value '\(dirtyName)'")
+    }
+}

--- a/ImageIntactTests/BackupManagerRunBackupTests.swift
+++ b/ImageIntactTests/BackupManagerRunBackupTests.swift
@@ -1,0 +1,271 @@
+//
+//  BackupManagerRunBackupTests.swift
+//  ImageIntactTests
+//
+//  TDD red-phase tests for BackupManager.runBackup alert extraction + bug fixes (AMUX-15).
+//
+//  These tests reference BackupAlertPresenting, PreflightSummary, NSAlertBackupPresenter,
+//  and the new BackupManager init parameters (backupAlertPresenter, deferredCleanupDelayNanos)
+//  — none of which exist yet. Compile failure here IS the red-phase signal.
+//
+//  NOTE: isProcessing is declared `var isProcessing = false` in BackupManager (not private(set)),
+//  so it is directly settable via @testable import. sourceTotalBytes is a computed property
+//  forwarding to sourceManager.sourceTotalBytes, which is an internal var — settable as
+//  bm.sourceManager.sourceTotalBytes = N directly from the test target.
+//
+//  Design doc: .planning/design/backup-manager-run-backup-extraction.md
+//
+
+import XCTest
+@testable import ImageIntact
+
+@MainActor
+final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
+
+    // MARK: - Test fixtures
+
+    var mockFileOps: MockFileOperations!
+    var mockPresenter: MockBackupAlertPresenter!
+    var mockDiskSpace: MockDiskSpaceChecker!
+
+    // Saved preferences to restore in tearDown.
+    private var savedShowPreflightSummary: Bool = false
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // Capture original state BEFORE resetting, so tearDown can restore it.
+        savedShowPreflightSummary = PreferencesManager.shared.showPreflightSummary
+
+        // Clear preferences state (bookmarks already cleared by base class).
+        PreferencesManager.shared.resetToDefaults()
+
+        mockFileOps = MockFileOperations()
+        mockPresenter = MockBackupAlertPresenter()
+        mockDiskSpace = MockDiskSpaceChecker()
+
+        // Default: disk space check passes with no warnings or errors.
+        mockDiskSpace.evaluationResult = (canProceed: true, warnings: [], errors: [])
+
+        // New init params (don't exist yet — compile failure is expected in red phase).
+        bm = BackupManager(
+            fileOperations: mockFileOps,
+            diskSpaceChecker: mockDiskSpace,
+            backupAlertPresenter: mockPresenter
+        )
+    }
+
+    override func tearDown() async throws {
+        // Reset to defaults first, then restore the captured original value
+        // last — so the restore is not immediately nullified by the reset call.
+        PreferencesManager.shared.resetToDefaults()
+        PreferencesManager.shared.showPreflightSummary = savedShowPreflightSummary
+
+        mockPresenter = nil
+        mockDiskSpace = nil
+        mockFileOps = nil
+
+        // Base class cancels any in-flight backup (reads self.bm before releasing it)
+        // and restores bookmarks. bm is released naturally when the test instance deinits.
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeURL(_ path: String) -> URL {
+        URL(fileURLWithPath: path)
+    }
+
+    /// Set a source + one destination so runBackup can reach the disk-space check.
+    private func setUpSourceAndDestination() {
+        bm.setSource(makeURL("/Volumes/CardA/DCIM"))
+        bm.setDestination(makeURL("/Volumes/BackupDrive"), at: 0)
+    }
+
+    // MARK: - Tests
+
+    /// Low fix verification: isProcessing guard prevents re-entrant runBackup.
+    /// With the guard in place, calling runBackup while already processing returns
+    /// immediately — no presenter calls, isProcessing stays true (not reset to false).
+    func testRunBackup_isProcessingGuard_earlyReturns() {
+        setUpSourceAndDestination()
+        bm.isProcessing = true
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentInsufficientSpaceCalls.count, 0,
+                       "No presenter calls when runBackup is re-entered")
+        XCTAssertEqual(mockPresenter.presentLowSpaceCalls.count, 0)
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 0)
+        // isProcessing stays true — the guard returns before clearing it.
+        XCTAssertTrue(bm.isProcessing,
+                      "isProcessing should remain true when guard fires")
+    }
+
+    /// Existing behavior preserved: no source → early return, no presenter calls.
+    func testRunBackup_missingSource_logsAndReturns() {
+        // No source set — sourceURL is nil.
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentInsufficientSpaceCalls.count, 0,
+                       "No presenter calls when source is missing")
+        XCTAssertEqual(mockPresenter.presentLowSpaceCalls.count, 0)
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 0)
+        XCTAssertFalse(bm.isProcessing,
+                       "isProcessing must be false after early-return (missing source)")
+    }
+
+    /// Insufficient space path: presenter receives the errors list; backup aborts.
+    func testRunBackup_insufficientSpace_callsPresenterAndReturns() {
+        setUpSourceAndDestination()
+        mockDiskSpace.evaluationResult = (
+            canProceed: false,
+            warnings: [],
+            errors: ["Insufficient space on BackupDrive: need 100 GB, only 10 GB available"]
+        )
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentInsufficientSpaceCalls.count, 1,
+                       "Presenter must be called exactly once for insufficient space")
+        XCTAssertEqual(mockPresenter.presentInsufficientSpaceCalls[0].count, 1,
+                       "Errors array should contain the one error message")
+        XCTAssertEqual(mockPresenter.presentLowSpaceCalls.count, 0,
+                       "Low-space presenter must not be called when errors are present")
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 0)
+        XCTAssertFalse(bm.isProcessing,
+                       "isProcessing must be false after insufficient-space early return")
+    }
+
+    /// Low space + user cancels: presenter fires once; backup aborts; preflight not called.
+    func testRunBackup_lowSpace_proceedFalse_returns() {
+        setUpSourceAndDestination()
+        mockDiskSpace.evaluationResult = (
+            canProceed: true,
+            warnings: ["Warning: BackupDrive will have less than 10% free after backup"],
+            errors: []
+        )
+        mockPresenter.lowSpaceReturnValue = false
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentLowSpaceCalls.count, 1,
+                       "Low-space presenter must be called once")
+        XCTAssertEqual(mockPresenter.presentInsufficientSpaceCalls.count, 0)
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 0,
+                       "Preflight must NOT be called when user declines low-space warning")
+        XCTAssertFalse(bm.isProcessing,
+                       "isProcessing must be false after user cancels low-space warning")
+    }
+
+    /// Low space + user continues + preflight enabled: both low-space and preflight called.
+    func testRunBackup_lowSpace_proceedTrue_proceedsToPreflight() {
+        setUpSourceAndDestination()
+        mockDiskSpace.evaluationResult = (
+            canProceed: true,
+            warnings: ["Warning: BackupDrive will have less than 10% free after backup"],
+            errors: []
+        )
+        mockPresenter.lowSpaceReturnValue = true
+        // Preflight must also be cancelled so runBackup doesn't try to launch the real backup.
+        mockPresenter.preflightReturnValue = (proceed: false, showAgain: true)
+        PreferencesManager.shared.showPreflightSummary = true
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentLowSpaceCalls.count, 1,
+                       "Low-space presenter must be called once")
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 1,
+                       "Preflight presenter must be called once when user proceeds past low-space")
+    }
+
+    /// Preflight cancelled: presenter fires once; backup aborts.
+    func testRunBackup_preflight_cancelled_returns() {
+        setUpSourceAndDestination()
+        mockPresenter.preflightReturnValue = (proceed: false, showAgain: true)
+        PreferencesManager.shared.showPreflightSummary = true
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 1,
+                       "Preflight presenter must be called once")
+        XCTAssertFalse(bm.isProcessing,
+                       "isProcessing must be false after user cancels preflight")
+    }
+
+    /// Preflight proceeds: isProcessing becomes true (backup started).
+    func testRunBackup_preflight_proceedTrue_setsIsProcessing() {
+        setUpSourceAndDestination()
+        mockPresenter.preflightReturnValue = (proceed: true, showAgain: true)
+        PreferencesManager.shared.showPreflightSummary = true
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 1)
+        XCTAssertTrue(bm.isProcessing,
+                      "isProcessing must be true after runBackup proceeds past preflight")
+    }
+
+    /// Suppression checkbox behavior: showAgain=false writes false to preferences.
+    func testRunBackup_preflight_showAgainFalse_writesPreferenceFalse() {
+        setUpSourceAndDestination()
+        PreferencesManager.shared.showPreflightSummary = true
+        // User unchecks "Show this summary before run" and clicks Start Backup.
+        mockPresenter.preflightReturnValue = (proceed: true, showAgain: false)
+
+        bm.runBackup()
+
+        XCTAssertFalse(PreferencesManager.shared.showPreflightSummary,
+                       "showPreflightSummary must be written back as false when showAgain=false")
+    }
+
+    /// High fix verification: disk-space gate uses sourceTotalBytes, not totalBytesToCopy.
+    /// We inject sourceManager state directly (bypassing setSource / prepareSource) to avoid
+    /// the synchronous reset: prepareSource clears sourceTotalBytes = 0 on every call, and
+    /// in test mode the async scan is suppressed, so calling setSource after setting the
+    /// bytes would zero them out with no scan to repopulate them.
+    func testRunBackup_diskSpaceUsesSourceTotalBytes() {
+        let expectedBytes: Int64 = 123_456_789
+
+        // MockDiskSpaceChecker captures `lastRequiredBytes` natively.
+        mockDiskSpace.evaluationResult = (canProceed: true, warnings: [], errors: [])
+        // Cancel at preflight so the backup doesn't actually start.
+        mockPresenter.preflightReturnValue = (proceed: false, showAgain: true)
+        PreferencesManager.shared.showPreflightSummary = true
+
+        // Inject source URL and byte count directly into sourceManager, bypassing
+        // prepareSource (which would synchronously reset sourceTotalBytes = 0 and skip
+        // the scan in test mode, leaving us with 0 bytes regardless of what we set before).
+        bm.sourceManager.sourceURL = makeURL("/Volumes/CardA/DCIM")
+        bm.sourceManager.sourceTotalBytes = expectedBytes
+        bm.setDestination(makeURL("/Volumes/BackupDrive"), at: 0)
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockDiskSpace.lastRequiredBytes, expectedBytes,
+                       "runBackup must pass sourceTotalBytes (not totalBytesToCopy) to the disk-space checker")
+    }
+
+    /// Fix 3 (missing happy path): preflight disabled + disk space OK → backup starts,
+    /// no alerts fire. Verifies that disabling the preflight summary skips the presenter
+    /// entirely and proceeds directly to setting isProcessing = true.
+    func testRunBackup_preflightDisabled_noWarnings_setsIsProcessingWithoutAlerts() {
+        // Preflight disabled — the presenter should never be asked to show the summary.
+        PreferencesManager.shared.showPreflightSummary = false
+
+        // Disk space defaults (set in setUp): canProceed = true, no warnings, no errors.
+        setUpSourceAndDestination()
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentInsufficientSpaceCalls.count, 0,
+                       "Insufficient-space presenter must not fire when space is fine")
+        XCTAssertEqual(mockPresenter.presentLowSpaceCalls.count, 0,
+                       "Low-space presenter must not fire when there are no warnings")
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 0,
+                       "Preflight presenter must not fire when preflight is disabled")
+        XCTAssertTrue(bm.isProcessing,
+                      "Backup should start immediately when preflight is disabled and space is fine")
+    }
+}

--- a/ImageIntactTests/Helpers/BaseBackupManagerTestCase.swift
+++ b/ImageIntactTests/Helpers/BaseBackupManagerTestCase.swift
@@ -1,0 +1,79 @@
+// IMPORTANT: These tests mutate `UserDefaults.standard` and `PreferencesManager.shared`.
+// They are NOT parallel-safe. If parallel test execution is enabled in the
+// Xcode scheme, these tests will overwrite each other's state and fail
+// nondeterministically.
+//
+// Until `PreferencesManager` is refactored behind a protocol with per-test
+// in-memory storage (deferred follow-up), keep parallel execution disabled
+// in the Xcode test plan for `ImageIntactTests`.
+
+import XCTest
+@testable import ImageIntact
+
+/// Shared base class for BackupManager test cases. Centralizes:
+/// - `BookmarkManager.sourceKey` / `destinationKeys` capture+restore (prevents
+///   the test suite from wiping a developer's saved bookmarks).
+/// - Cancellation of any in-flight backup before pref restoration (prevents
+///   orphaned Tasks if a test exits early or fails mid-flight).
+///
+/// Per-test files are still responsible for capturing/restoring any
+/// `PreferencesManager.shared.X` values they specifically mutate (e.g.
+/// `showPreflightSummary`, `lastUsedOrganizationFolderName`). The base class
+/// just handles bookmarks because those are universal.
+///
+/// Subclasses MUST set `bm` to the BackupManager under test in their setUp
+/// (after calling `super.setUp()`) so the teardown cancellation check works.
+@MainActor
+class BaseBackupManagerTestCase: XCTestCase {
+    /// The BackupManager under test. Subclass setUp assigns this so the
+    /// base tearDown can cancel any in-flight backup.
+    var bm: BackupManager!
+
+    private var savedSourceBookmark: Any?
+    private var savedDestinationBookmarks: [String: Any] = [:]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Capture bookmark state BEFORE clearing so we can restore in tearDown.
+        savedSourceBookmark = UserDefaults.standard.object(forKey: BookmarkManager.sourceKey)
+        savedDestinationBookmarks = [:]
+        for key in BookmarkManager.destinationKeys {
+            if let v = UserDefaults.standard.object(forKey: key) {
+                savedDestinationBookmarks[key] = v
+            }
+        }
+        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        for key in BookmarkManager.destinationKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    override func tearDown() async throws {
+        // Cancel any in-flight backup before pref restoration, so spawned
+        // Tasks (e.g. `performQueueBasedBackup`) don't leak past this test.
+        if bm?.isProcessing == true {
+            bm.cancelOperation()
+        }
+
+        // Restore bookmarks. Conditional set-or-remove so absent keys stay absent.
+        if let v = savedSourceBookmark {
+            UserDefaults.standard.set(v, forKey: BookmarkManager.sourceKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        }
+        for key in BookmarkManager.destinationKeys {
+            if let v = savedDestinationBookmarks[key] {
+                UserDefaults.standard.set(v, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        // Release the BackupManager so its dependency graph deinits between
+        // test methods. We do this AFTER the cancellation check above —
+        // releasing before that would defeat the safeguard.
+        bm = nil
+
+        try await super.tearDown()
+    }
+}

--- a/ImageIntactTests/Mocks/MockBackupAlertPresenter.swift
+++ b/ImageIntactTests/Mocks/MockBackupAlertPresenter.swift
@@ -1,0 +1,54 @@
+//
+//  MockBackupAlertPresenter.swift
+//  ImageIntactTests
+//
+//  Mock implementation of BackupAlertPresenting for testing
+//  BackupManager.runBackup alert paths.
+//
+//  Design doc: .planning/design/backup-manager-run-backup-extraction.md
+//
+
+import Foundation
+@testable import ImageIntact
+
+/// Test double for BackupAlertPresenting. Records all calls and returns
+/// configurable values so tests can assert on which alert path fired without
+/// triggering real NSAlert modals.
+@MainActor
+final class MockBackupAlertPresenter: BackupAlertPresenting {
+
+    // MARK: - Call recording
+
+    /// Each element is the `errors` array passed to presentInsufficientSpaceAlert.
+    var presentInsufficientSpaceCalls: [[String]] = []
+
+    /// Each element is the `warnings` array passed to presentLowSpaceWarning.
+    var presentLowSpaceCalls: [[String]] = []
+
+    /// Each element is the PreflightSummary passed to presentPreflightSummary.
+    var presentPreflightCalls: [PreflightSummary] = []
+
+    // MARK: - Configurable return values
+
+    /// Return value for presentLowSpaceWarning. Default true = "Continue".
+    var lowSpaceReturnValue = true
+
+    /// Return value for presentPreflightSummary. Default (true, true) = proceed + show again.
+    var preflightReturnValue: (proceed: Bool, showAgain: Bool) = (true, true)
+
+    // MARK: - BackupAlertPresenting
+
+    func presentInsufficientSpaceAlert(errors: [String]) {
+        presentInsufficientSpaceCalls.append(errors)
+    }
+
+    func presentLowSpaceWarning(warnings: [String]) -> Bool {
+        presentLowSpaceCalls.append(warnings)
+        return lowSpaceReturnValue
+    }
+
+    func presentPreflightSummary(_ summary: PreflightSummary) -> (proceed: Bool, showAgain: Bool) {
+        presentPreflightCalls.append(summary)
+        return preflightReturnValue
+    }
+}

--- a/ImageIntactTests/Mocks/MockBackupOrchestrator.swift
+++ b/ImageIntactTests/Mocks/MockBackupOrchestrator.swift
@@ -1,0 +1,39 @@
+//
+//  MockBackupOrchestrator.swift
+//  ImageIntactTests
+//
+//  Subclass of BackupOrchestrator that records cancel() calls for
+//  cancel-ordering verification in BackupManagerCancelTests.
+//
+//  BackupOrchestrator is declared `class BackupOrchestrator` (not final, not open).
+//  With `@testable import ImageIntact`, internal classes are accessible from the
+//  test target and can be subclassed. Subclass approach is used here per the design doc.
+//
+//  If this fails to compile (e.g. the compiler treats the class as effectively
+//  non-subclassable across module boundaries), fall back to the approach documented
+//  in the design doc §"MockBackupOrchestrator": add a test-only internal accessor
+//  `var isCancelled: Bool { shouldCancel }` to BackupOrchestrator and use the real
+//  orchestrator in the test.
+//
+//  Design doc: .planning/design/backup-manager-run-backup-extraction.md
+//
+
+import Foundation
+@testable import ImageIntact
+
+/// Test double for BackupOrchestrator that counts cancel() invocations.
+/// Used to verify the Blocker fix: orchestrator.cancel() is called synchronously
+/// before cleanupMemory() nils currentOrchestrator.
+@MainActor
+final class MockBackupOrchestrator: BackupOrchestrator {
+
+    var cancelCallCount = 0
+
+    override func cancel() {
+        cancelCallCount += 1
+        // We intentionally do NOT call super.cancel() — this mock records the call
+        // for ordering assertions only. The real BackupOrchestrator.cancel() spawns
+        // a MainActor Task and touches ProgressTracker, which we don't want to fire
+        // in unit tests.
+    }
+}

--- a/ImageIntactTests/UIStateManagementTests.swift
+++ b/ImageIntactTests/UIStateManagementTests.swift
@@ -97,7 +97,10 @@ class UIStateManagementTests: XCTestCase {
         backupManager.cancelOperation()
 
         XCTAssertTrue(backupManager.shouldCancel)
-        XCTAssertTrue(backupManager.statusMessage.contains("Cancelling"))
+        // After AMUX-15, state mutations in cancelOperation are synchronous (formerly
+        // wrapped in an async Task). By the time cancelOperation returns, the status
+        // has already advanced from "Cancelling backup..." to "Backup cancelled".
+        XCTAssertEqual(backupManager.statusMessage, "Backup cancelled")
     }
 
     // MARK: - Failed Files Tracking


### PR DESCRIPTION
## Summary
AMUX-15 / refs #103. Mirrors PR #118's `DestinationAlertPresenter` pattern for the three `runBackup` NSAlerts (insufficient/low-space/preflight), AND lands the panel-flagged correctness fixes from PR #117 that were deferred to this PR.

`BackupManager.swift`: 694 → 614 lines (-80).

## Fixes (each enumerated against the PR #117 panel-review finding)

### Blocker — Orchestrator cancellation race
`cancelOperation()` previously scheduled `orchestrator.cancel()` inside an async `Task`, then synchronously called `cleanupMemory()` which nil'd `currentOrchestrator`. The Task ran after the ref was nil → cancel never reached the orchestrator → backup kept running invisibly.
**Fix:** local strong ref captured at the top of `cancelOperation`. `orchestratorRef?.cancel()` fires synchronously, before `cleanupMemory()`.

### High — Delayed cleanupMemory race
`cleanupMemory()` scheduled a 10s-deferred `Task` that wiped `failedFiles`/`progressTracker`/`statistics`. A new backup within 10s got its state wiped mid-flight.
**Fix:** `internal var deferredCleanupTask: Task<Void, Never>?` is cancelled at the top of each `cleanupMemory()` call, and the deferred body captures `sessionID` and bails if it changed.

### High — Pre-flight disk-space wrong variable
`runBackup` was passing `totalBytesToCopy` (a progress var populated AFTER orchestrator runs — 0 or stale at preflight) to the disk-space checker. Gate was non-functional.
**Fix:** swapped to `sourceTotalBytes` (populated at source-scan time).

### Low — organizationName sanitization bypass at init
Direct assignment `organizationName = lastUsedName` in init bypassed the `didSet` sanitize hook (Swift initialization semantics).
**Fix:** wrap the assignment in `SmartFolderName.sanitize(...)`.

### Low — Empty autoreleasepool
Two `autoreleasepool {}` no-op blocks in `cleanupMemory`.
**Fix:** removed.

### Low — Missing isProcessing guard
`canRunBackup()` checks `!isProcessing`, but `runBackup()` itself didn't.
**Fix:** added `guard !isProcessing` at top of `runBackup`.

## Cancel-operation completions from plan review

Two changes tightly coupled to the new `isProcessing` guard, included because without them the guard regresses correctness:

- Immediate state mutations in `cancelOperation` (progressTracker reset, currentPhase = .idle, status message, etc.) moved OUT of the async Task — was deferred by one runloop turn, which broke the guard on rapid cancel→backup.
- `isProcessing = false` flips AFTER `orchestratorRef?.cancel()` so the UI can't re-enable while the prior orchestrator is still tearing down.

`runBackup` state setup now also calls `statistics.reset()` and `progressTracker.resetAll()` so a new backup doesn't inherit leftover state when the prior deferred cleanup bails on session change.

## Tests
- 18 new test cases:
  - `BackupManagerRunBackupTests` (10): all alert paths, isProcessing guard, disk-space-uses-sourceTotalBytes, preferences write, happy path with preflight disabled.
  - `BackupManagerCancelTests` (4): cancel-before-nil, double-call ignored, isProcessing=false synchronous, large-backup-continuation cleared.
  - `BackupManagerCleanupTests` (3): deferred cleanup runs when session unchanged, bails when session changes, second call cancels first deferred task.
  - `BackupAlertPresenterTests` (1 smoke), `BackupManagerOrganizationNameInitTests` (1).
- New `BaseBackupManagerTestCase` centralizes bookmark capture/restore (prevents developer-bookmark-wipe local hazard) and in-flight-backup cancellation in tearDown.
- Updated `UIStateManagementTests.testCancellationFlow` to reflect the new synchronous state ordering: post-cancel status is now "Backup cancelled" immediately (was "Cancelling backup..." with the old async-Task ordering).
- `MockDiskSpaceChecker` gains a `lastRequiredBytes` capture field (replaces a non-functional subclass attempt).

All 18 new tests pass. Pre-existing failures in `ManifestBuilderFilterTests` / `SubdirectoryTraversalTests` are unchanged — same set PR #118 documented as unrelated.

## Process
- 3 rounds of Gemini plan review against `.planning/design/backup-manager-run-backup-extraction.md` — all High findings resolved or explicitly responded to in the doc.
- 6 rounds of Gemini panel review against the test code, ended 0 Blocker / 0 High.
- Final post-impl build verified on bot-mini.

## Documented follow-ups (not in this PR)
- BackupOrchestrating protocol extraction so `MockBackupOrchestrator` doesn't subclass concrete class.
- PreferencesManager DI behind a protocol so tests don't mutate `UserDefaults.standard` directly. (Capture-and-restore is the interim mitigation.)
- Block `runBackup` while source scan is in progress (sourceTotalBytes can be 0 if user clicks Backup mid-scan).
- Empty-destinations guard in `runBackup` (currently UI-gated via `canRunBackup`).
- `SmartFolderName.sanitize` allowlist coverage.
- Cancelled-state badges flash and disappear on cancel (resetAll wipes the just-set "cancelled" states; pre-existing UX).

## Refs
AMUX-15, refs #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)