### PR TITLE
refactor: empty-destinations guard in runBackup (AMUX-208)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -409,6 +409,12 @@ class BackupManager {
         }
 
         let destinations = destinationURLs.compactMap { $0 }
+        // AMUX-208: empty-destinations guard. UI gates this via canRunBackup(),
+        // but runBackup itself didn't — a programmatic re-entry could fall through.
+        guard !destinations.isEmpty else {
+            logWarning("runBackup called with no destinations — ignoring")
+            return
+        }
 
         // Check disk space for all destinations.
         // High fix: use sourceTotalBytes (set at scan time) not totalBytesToCopy

--- a/ImageIntactTests/BackupManagerRunBackupTests.swift
+++ b/ImageIntactTests/BackupManagerRunBackupTests.swift
@@ -102,6 +102,22 @@ final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
                       "isProcessing should remain true when guard fires")
     }
 
+    /// AMUX-208: empty destinations → early return, no presenter calls.
+    /// Mirrors the missing-source guard. Same shape as the AMUX-15 isProcessing guard.
+    func testRunBackup_emptyDestinations_logsAndReturns() {
+        bm.setSource(makeURL("/Volumes/CardA/DCIM"))
+        // Intentionally do NOT call setDestination — destinationURLs stays []/[nil].
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentInsufficientSpaceCalls.count, 0,
+                       "No presenter calls when destinations is empty")
+        XCTAssertEqual(mockPresenter.presentLowSpaceCalls.count, 0)
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 0)
+        XCTAssertFalse(bm.isProcessing,
+                       "isProcessing must be false after early-return (empty destinations)")
+    }
+
     /// Existing behavior preserved: no source → early return, no presenter calls.
     func testRunBackup_missingSource_logsAndReturns() {
         // No source set — sourceURL is nil.


### PR DESCRIPTION
## Summary
AMUX-208. Follow-up from PR #119 / AMUX-15 plan review. Adds an empty-destinations guard at the top of `runBackup()` — same shape as the just-added isProcessing and missing-source guards. The UI gates this via `canRunBackup()`, but `runBackup()` itself didn't — a programmatic re-entry would fall through.

## Change
```swift
let destinations = destinationURLs.compactMap { $0 }
guard !destinations.isEmpty else {
    logWarning("runBackup called with no destinations — ignoring")
    return
}
```

## Test
One new case: `testRunBackup_emptyDestinations_logsAndReturns`. Sets a source, deliberately skips `setDestination`, calls `runBackup`, asserts zero presenter calls and `isProcessing == false`. All 19 cases in `BackupManagerRunBackupTests` pass; the rest of the Fast plan is unchanged from PR #119's baseline.

## Refs
AMUX-208, follow-up from AMUX-15 / PR #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)