### PR TITLE
refactor: extract BackupOrchestrating protocol (AMUX-204)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -223,7 +223,7 @@ class BackupManager {
     }
 
     var logEntries: [LogEntry] = []
-    var currentOrchestrator: BackupOrchestrator?
+    var currentOrchestrator: BackupOrchestrating?
 
     // MARK: - Initialization
 

--- a/ImageIntact/Models/BackupOrchestrator.swift
+++ b/ImageIntact/Models/BackupOrchestrator.swift
@@ -1,10 +1,23 @@
 import AppKit
 import Foundation
 
+/// Minimal protocol surface that `BackupManager` needs from a backup orchestrator.
+/// Exposes only `cancel()` because that's the only method `BackupManager` calls
+/// against `currentOrchestrator`. Keeps mock-able surface small and prevents
+/// the test double from having to subclass the concrete class.
+///
+/// `AnyObject` constraint: orchestrators have identity (BackupManager tracks
+/// the current one via a stored reference) and `weak` capture semantics are
+/// used in cancellation Tasks.
+@MainActor
+protocol BackupOrchestrating: AnyObject {
+    func cancel()
+}
+
 /// Orchestrates the entire backup process by coordinating between components
 /// This is the top-level controller that manages ManifestBuilder, ProgressTracker, and BackupCoordinator
 @MainActor
-class BackupOrchestrator {
+class BackupOrchestrator: BackupOrchestrating {
     // MARK: - Components
 
     private let manifestBuilder = ManifestBuilder()

--- a/ImageIntactTests/BackupManagerCancelTests.swift
+++ b/ImageIntactTests/BackupManagerCancelTests.swift
@@ -48,10 +48,7 @@ final class BackupManagerCancelTests: BaseBackupManagerTestCase {
     /// cancel was scheduled in a Task — this test asserts the count without any
     /// Task.yield, so it would be 0 with the old code.
     func testCancelOperation_cancelsOrchestratorBeforeNil() {
-        let mockOrch = MockBackupOrchestrator(
-            progressTracker: ProgressTracker(),
-            resourceManager: ResourceManager()
-        )
+        let mockOrch = MockBackupOrchestrator()
         bm.currentOrchestrator = mockOrch
         bm.isProcessing = true
 
@@ -64,10 +61,7 @@ final class BackupManagerCancelTests: BaseBackupManagerTestCase {
 
     /// shouldCancel guard: second cancelOperation call is ignored.
     func testCancelOperation_doubleCallIgnored() {
-        let mockOrch = MockBackupOrchestrator(
-            progressTracker: ProgressTracker(),
-            resourceManager: ResourceManager()
-        )
+        let mockOrch = MockBackupOrchestrator()
         bm.currentOrchestrator = mockOrch
         bm.isProcessing = true
 

--- a/ImageIntactTests/Mocks/MockBackupOrchestrator.swift
+++ b/ImageIntactTests/Mocks/MockBackupOrchestrator.swift
@@ -2,38 +2,27 @@
 //  MockBackupOrchestrator.swift
 //  ImageIntactTests
 //
-//  Subclass of BackupOrchestrator that records cancel() calls for
-//  cancel-ordering verification in BackupManagerCancelTests.
+//  Implements BackupOrchestrating (the minimal protocol BackupManager needs).
+//  Records cancel() invocations for cancel-ordering verification in
+//  BackupManagerCancelTests.
 //
-//  BackupOrchestrator is declared `class BackupOrchestrator` (not final, not open).
-//  With `@testable import ImageIntact`, internal classes are accessible from the
-//  test target and can be subclassed. Subclass approach is used here per the design doc.
-//
-//  If this fails to compile (e.g. the compiler treats the class as effectively
-//  non-subclassable across module boundaries), fall back to the approach documented
-//  in the design doc §"MockBackupOrchestrator": add a test-only internal accessor
-//  `var isCancelled: Bool { shouldCancel }` to BackupOrchestrator and use the real
-//  orchestrator in the test.
-//
-//  Design doc: .planning/design/backup-manager-run-backup-extraction.md
+//  AMUX-204 (PR #122): converted from a subclass of BackupOrchestrator to a
+//  direct protocol implementation. The subclass approach was an anti-pattern
+//  (Fragile Base Class, awkward ProgressTracker/ResourceManager init dance,
+//  recurring panel-review item) — implementing the protocol directly removes
+//  all of that.
 //
 
 import Foundation
 @testable import ImageIntact
 
-/// Test double for BackupOrchestrator that counts cancel() invocations.
-/// Used to verify the Blocker fix: orchestrator.cancel() is called synchronously
-/// before cleanupMemory() nils currentOrchestrator.
+/// Records `cancel()` invocations for the cancellation-ordering tests.
 @MainActor
-final class MockBackupOrchestrator: BackupOrchestrator {
+final class MockBackupOrchestrator: BackupOrchestrating {
 
     var cancelCallCount = 0
 
-    override func cancel() {
+    func cancel() {
         cancelCallCount += 1
-        // We intentionally do NOT call super.cancel() — this mock records the call
-        // for ordering assertions only. The real BackupOrchestrator.cancel() spawns
-        // a MainActor Task and touches ProgressTracker, which we don't want to fire
-        // in unit tests.
     }
 }


### PR DESCRIPTION
## Summary
AMUX-204. Recurring panel-review item across PR #119's 3 rounds and the AMUX-15 test panel's 6 rounds. `MockBackupOrchestrator` previously subclassed the concrete `BackupOrchestrator` class — Fragile Base Class anti-pattern. Now implements a minimal protocol directly.

## Protocol
```swift
@MainActor
protocol BackupOrchestrating: AnyObject {
    func cancel()
}
```

`BackupManager` only ever calls `cancel()` through `currentOrchestrator`, so that's all the protocol exposes. `AnyObject` constraint preserves identity semantics (BackupManager tracks the active orchestrator by reference; cancellation Tasks use `[weak self]`).

## Changes
- `BackupOrchestrator.swift`: declares the protocol; concrete class conforms.
- `BackupManager.swift`: `var currentOrchestrator: BackupOrchestrator?` → `BackupOrchestrating?`. Single call site (`orchestratorRef?.cancel()` in `cancelOperation`) works unchanged via dynamic dispatch.
- `MockBackupOrchestrator.swift`: drops the `init(progressTracker:resourceManager:)` super-call dance and the "don't call super.cancel()" comment. Plain protocol-conforming class.
- `BackupManagerCancelTests.swift`: `MockBackupOrchestrator(progressTracker: ProgressTracker(), resourceManager: ResourceManager())` → `MockBackupOrchestrator()`.

`BackupManagerQueueIntegration` still constructs `BackupOrchestrator(...)` concretely — only the BackupManager *property* type narrowed. No cascade outside the four files above.

## Tests
All 18 AMUX-15 test cases + 4 cancel tests + 3 cleanup tests pass. No new tests required — the protocol extraction is a pure structural change with no observable behavior change.

## Refs
AMUX-204, follow-up from AMUX-15 / PR #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)