### PR TITLE
refactor: PreferencesProviding protocol + DI in BackupManager (AMUX-205)

### DIFF
--- a/ImageIntact.xctestplan
+++ b/ImageIntact.xctestplan
@@ -17,7 +17,7 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : false,
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:ImageIntact.xcodeproj",
         "identifier" : "71592B6A2E3CE71700571AB3",

--- a/ImageIntact.xctestplan
+++ b/ImageIntact.xctestplan
@@ -17,7 +17,7 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:ImageIntact.xcodeproj",
         "identifier" : "71592B6A2E3CE71700571AB3",

--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -34,6 +34,7 @@ class BackupManager {
     let notificationService: NotificationProtocol
     let driveAnalyzer: DriveAnalyzerProtocol
     let diskSpaceChecker: DiskSpaceProtocol
+    let preferences: PreferencesProviding
 
     // MARK: - Delegated Managers
 
@@ -179,7 +180,7 @@ class BackupManager {
 
     // Duplicate detection state
     var enableDuplicateDetection: Bool {
-        PreferencesManager.shared.enableSmartDuplicateDetection
+        preferences.enableSmartDuplicateDetection
     }
 
     var showDuplicateWarning = false
@@ -235,6 +236,7 @@ class BackupManager {
         duplicateDetector: DuplicateDetectorProtocol? = nil,
         destinationAlertPresenter: DestinationAlertPresenting? = nil,
         backupAlertPresenter: BackupAlertPresenting? = nil,
+        preferences: PreferencesProviding = PreferencesManager.shared,
         deferredCleanupDelayNanos: UInt64 = 10_000_000_000
     ) {
         // Use provided dependencies or create real implementations
@@ -248,6 +250,7 @@ class BackupManager {
         self.duplicateDetector = duplicateDetector ?? DuplicateDetector()
         self.destinationAlertPresenter = destinationAlertPresenter ?? NSAlertDestinationPresenter()
         self.backupAlertPresenter = backupAlertPresenter ?? NSAlertBackupPresenter()
+        self.preferences = preferences
         self.deferredCleanupDelayNanos = deferredCleanupDelayNanos
 
         // Create delegated managers
@@ -260,7 +263,7 @@ class BackupManager {
 
         // Initialize organization name from last used (if user previously customized).
         // Wrap in SmartFolderName.sanitize because didSet doesn't fire during init.
-        if let lastUsedName = PreferencesManager.shared.lastUsedOrganizationFolderName {
+        if let lastUsedName = preferences.lastUsedOrganizationFolderName {
             organizationName = SmartFolderName.sanitize(lastUsedName)
         }
 
@@ -271,7 +274,7 @@ class BackupManager {
         }
 
         // Restore last session if enabled
-        if PreferencesManager.shared.restoreLastSession {
+        if preferences.restoreLastSession {
             destinationManager.loadFromSession()
             if let restoredURL = sourceManager.loadFromSession(), !BackupManager.isRunningTests {
                 Task { [sourceManager] in
@@ -449,11 +452,11 @@ class BackupManager {
         }
 
         // Pre-flight summary (if enabled).
-        if PreferencesManager.shared.showPreflightSummary {
+        if preferences.showPreflightSummary {
             let summary = buildPreflightSummary(source: source, destinations: destinations)
             let (proceed, showAgain) = backupAlertPresenter.presentPreflightSummary(summary)
             guard proceed else { return }
-            PreferencesManager.shared.showPreflightSummary = showAgain
+            preferences.showPreflightSummary = showAgain
         }
 
         // State setup — reset everything cleanupMemory's deferred task would have
@@ -470,8 +473,8 @@ class BackupManager {
 
         // Save organization folder name to recent list and as last used
         if !organizationName.isEmpty {
-            PreferencesManager.shared.addRecentOrganizationFolderName(organizationName)
-            PreferencesManager.shared.lastUsedOrganizationFolderName = organizationName
+            preferences.addRecentOrganizationFolderName(organizationName)
+            preferences.lastUsedOrganizationFolderName = organizationName
         }
 
         // Start preventing sleep
@@ -517,8 +520,8 @@ class BackupManager {
             totalFiles: nonFilteredTotalFiles,
             totalBytes: sourceTotalBytes,
             destinations: destTuples,
-            excludeCacheFiles: PreferencesManager.shared.excludeCacheFiles,
-            skipHiddenFiles: PreferencesManager.shared.skipHiddenFiles,
+            excludeCacheFiles: preferences.excludeCacheFiles,
+            skipHiddenFiles: preferences.skipHiddenFiles,
             fileTypeFilterActive: !fileTypeFilter.includedExtensions.isEmpty
         )
     }

--- a/ImageIntact/Models/BackupManagerQueueIntegration.swift
+++ b/ImageIntact/Models/BackupManagerQueueIntegration.swift
@@ -520,7 +520,7 @@ extension BackupManager {
         // Show completion report if not cancelled
         if !shouldCancel {
             // Send notification if enabled
-            if PreferencesManager.shared.showNotificationOnComplete {
+            if preferences.showNotificationOnComplete {
                 notificationService.sendBackupCompletionNotification(
                     filesCopied: progressTracker.processedFiles,
                     destinations: destinations.count,
@@ -533,7 +533,7 @@ extension BackupManager {
             showCompletionReport = true
 
             // Offer to trash source if enabled and backup was fully successful
-            if PreferencesManager.shared.trashSourceAfterBackup
+            if preferences.trashSourceAfterBackup
                 && failedFiles.isEmpty
                 && sourceURL != nil
             {
@@ -678,14 +678,14 @@ extension BackupManager {
         source _: URL, destinations: [URL], manifest: [FileManifestEntry]
     ) async -> Bool {
         ApplicationLogger.shared.debug(
-            "Checking for large backup (threshold: \(PreferencesManager.shared.largeBackupFileThreshold) files / \(PreferencesManager.shared.largeBackupSizeThresholdGB) GB)",
+            "Checking for large backup (threshold: \(preferences.largeBackupFileThreshold) files / \(preferences.largeBackupSizeThresholdGB) GB)",
             category: .backup
         )
 
         // Skip if user disabled confirmations or already disabled warnings
         guard
-            PreferencesManager.shared.confirmLargeBackups
-            && !PreferencesManager.shared.skipLargeBackupWarning
+            preferences.confirmLargeBackups
+            && !preferences.skipLargeBackupWarning
         else {
             return true // Proceed with backup
         }
@@ -695,9 +695,9 @@ extension BackupManager {
 
         statusMessage = "Analyzing backup size..."
 
-        let fileThreshold = PreferencesManager.shared.largeBackupFileThreshold
+        let fileThreshold = preferences.largeBackupFileThreshold
         let sizeThresholdBytes = Int64(
-            PreferencesManager.shared.largeBackupSizeThresholdGB * 1_000_000_000)
+            preferences.largeBackupSizeThresholdGB * 1_000_000_000)
         let totalBytes = manifest.reduce(0) { $0 + $1.size }
 
         // Check if backup exceeds thresholds
@@ -738,7 +738,7 @@ extension BackupManager {
         largeBackupInfo = nil
 
         if dontShowAgain {
-            PreferencesManager.shared.skipLargeBackupWarning = true
+            preferences.skipLargeBackupWarning = true
         }
 
         // Resume the waiting backup process

--- a/ImageIntact/Models/BackupManagerQueueIntegration.swift
+++ b/ImageIntact/Models/BackupManagerQueueIntegration.swift
@@ -511,9 +511,12 @@ extension BackupManager {
         statistics.completeBackup()
     }
 
-    /// Handle backup completion (notifications and UI)
+    /// Handle backup completion (notifications and UI).
+    /// `internal` (not `private`) so tests can drive it directly with mocked
+    /// `preferences` / `notificationService` and assert which prefs reads gate
+    /// which side effects (AMUX-205 panel review round 4).
     @MainActor
-    private func handleBackupCompletion(destinations: [URL]) async {
+    func handleBackupCompletion(destinations: [URL]) async {
         // Stop preventing sleep
         SleepPrevention.shared.stopPreventingSleep()
 
@@ -671,10 +674,13 @@ extension BackupManager {
 
     // MARK: - Large Backup Confirmation
 
-    /// Check if this is a large backup and wait for user confirmation if needed
-    /// Returns true if backup should proceed, false if user cancelled
+    /// Check if this is a large backup and wait for user confirmation if needed.
+    /// Returns true if backup should proceed, false if user cancelled.
+    /// `internal` (not `private`) so tests can drive the early-return branches
+    /// directly and assert which prefs reads gate which behavior (AMUX-205
+    /// panel review round 4).
     @MainActor
-    private func checkForLargeBackupAndWait(
+    func checkForLargeBackupAndWait(
         source _: URL, destinations: [URL], manifest: [FileManifestEntry]
     ) async -> Bool {
         ApplicationLogger.shared.debug(

--- a/ImageIntact/Models/PreferencesManager.swift
+++ b/ImageIntact/Models/PreferencesManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-class PreferencesManager: ObservableObject {
+class PreferencesManager: ObservableObject, PreferencesProviding {
     static let shared = PreferencesManager()
 
     // MARK: - General Preferences

--- a/ImageIntact/Models/Protocols/PreferencesProviding.swift
+++ b/ImageIntact/Models/Protocols/PreferencesProviding.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The subset of `PreferencesManager` that `BackupManager` depends on.
+///
+/// BackupManager reads (and in a few cases writes) these preferences. Injecting
+/// a `PreferencesProviding` instead of touching `PreferencesManager.shared`
+/// directly lets tests use a per-instance in-memory provider — no shared
+/// `UserDefaults` mutation, no cross-test bleed.
+///
+/// Class-only (`AnyObject`) so writes to `var` properties are visible to all
+/// holders, matching the reference-semantics behavior of `PreferencesManager.shared`.
+protocol PreferencesProviding: AnyObject {
+    /// Smart duplicate detection toggle (BackupManager.enableDuplicateDetection).
+    var enableSmartDuplicateDetection: Bool { get }
+
+    /// Last user-entered organization folder name. Read at BackupManager init
+    /// (to restore the previous session's name) and written when a backup starts
+    /// with a non-empty `organizationName`.
+    var lastUsedOrganizationFolderName: String? { get set }
+
+    /// Whether to restore the previous session's source + destinations at startup.
+    var restoreLastSession: Bool { get }
+
+    /// Whether to show the pre-flight summary alert before a backup. May be
+    /// written back as `false` if the user opts out from the alert itself.
+    var showPreflightSummary: Bool { get set }
+
+    /// Whether to exclude image-editor cache files from manifests.
+    var excludeCacheFiles: Bool { get }
+
+    /// Whether to skip OS hidden / metadata files from manifests.
+    var skipHiddenFiles: Bool { get }
+
+    /// Whether to send a system notification on backup completion.
+    var showNotificationOnComplete: Bool { get }
+
+    /// Whether to offer "move source to Trash" after a successful backup.
+    var trashSourceAfterBackup: Bool { get }
+
+    /// File-count threshold above which a backup counts as "large" (warning gate).
+    var largeBackupFileThreshold: Int { get }
+
+    /// Total-size threshold (GB) above which a backup counts as "large".
+    var largeBackupSizeThresholdGB: Double { get }
+
+    /// Whether to gate large backups behind a confirmation alert.
+    var confirmLargeBackups: Bool { get }
+
+    /// Suppresses the large-backup warning. Written when the user picks
+    /// "don't show again" from the confirmation.
+    var skipLargeBackupWarning: Bool { get set }
+
+    /// Records the supplied folder name as recently-used. Most-recent first;
+    /// duplicates move to the top; caller-side cap of 10 entries.
+    func addRecentOrganizationFolderName(_ name: String)
+}

--- a/ImageIntactTests/BackupManagerCancelTests.swift
+++ b/ImageIntactTests/BackupManagerCancelTests.swift
@@ -20,20 +20,20 @@ final class BackupManagerCancelTests: BaseBackupManagerTestCase {
     // MARK: - Test fixtures
 
     var mockFileOps: MockFileOperations!
+    var prefs: InMemoryPreferencesProvider!
 
     override func setUp() async throws {
         try await super.setUp()
 
-        // Clear preferences state (bookmarks already cleared by base class).
-        PreferencesManager.shared.resetToDefaults()
-
         mockFileOps = MockFileOperations()
-        bm = BackupManager(fileOperations: mockFileOps)
+        prefs = InMemoryPreferencesProvider()
+
+        // AMUX-205: inject prefs so this test never mutates PreferencesManager.shared.
+        bm = BackupManager(fileOperations: mockFileOps, preferences: prefs)
     }
 
     override func tearDown() async throws {
-        PreferencesManager.shared.resetToDefaults()
-
+        prefs = nil
         mockFileOps = nil
 
         // Base class cancels any in-flight backup (reads self.bm before releasing it)

--- a/ImageIntactTests/BackupManagerCleanupTests.swift
+++ b/ImageIntactTests/BackupManagerCleanupTests.swift
@@ -29,20 +29,15 @@ final class BackupManagerCleanupTests: BaseBackupManagerTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        // Clear preferences state (bookmarks already cleared by base class).
-        PreferencesManager.shared.resetToDefaults()
-
         mockFileOps = MockFileOperations()
         // Note: bm is not pre-assigned here — each test assigns self.bm with its own
-        // BackupManager (custom deferredCleanupDelayNanos). The base class tearDown will
-        // cancel any in-flight backup via self.bm before releasing it.
+        // BackupManager (custom deferredCleanupDelayNanos + injected
+        // InMemoryPreferencesProvider). The base class tearDown will cancel any
+        // in-flight backup via self.bm before releasing it.
     }
 
     override func tearDown() async throws {
-        PreferencesManager.shared.resetToDefaults()
-
         mockFileOps = nil
-
         // Base class cancels any in-flight backup via self.bm and restores bookmarks.
         try await super.tearDown()
     }
@@ -68,6 +63,7 @@ final class BackupManagerCleanupTests: BaseBackupManagerTestCase {
         // Assigned to self.bm so the base class tearDown can cancel any in-flight work.
         self.bm = BackupManager(
             fileOperations: mockFileOps,
+            preferences: InMemoryPreferencesProvider(),
             deferredCleanupDelayNanos: 50_000_000  // 50ms
         )
 
@@ -105,6 +101,7 @@ final class BackupManagerCleanupTests: BaseBackupManagerTestCase {
         // Assigned to self.bm so the base class tearDown can cancel any in-flight work.
         self.bm = BackupManager(
             fileOperations: mockFileOps,
+            preferences: InMemoryPreferencesProvider(),
             deferredCleanupDelayNanos: 50_000_000  // 50ms
         )
 
@@ -133,6 +130,7 @@ final class BackupManagerCleanupTests: BaseBackupManagerTestCase {
         // Assigned to self.bm so the base class tearDown can cancel any in-flight work.
         self.bm = BackupManager(
             fileOperations: mockFileOps,
+            preferences: InMemoryPreferencesProvider(),
             deferredCleanupDelayNanos: 50_000_000  // 50ms
         )
 

--- a/ImageIntactTests/BackupManagerOrganizationNameInitTests.swift
+++ b/ImageIntactTests/BackupManagerOrganizationNameInitTests.swift
@@ -2,16 +2,17 @@
 //  BackupManagerOrganizationNameInitTests.swift
 //  ImageIntactTests
 //
-//  TDD red-phase tests for the BackupManager init organizationName sanitization fix (AMUX-15).
+//  Tests for the BackupManager init organizationName sanitization fix (AMUX-15).
 //
 //  Low fix: organizationName = lastUsedName at init bypassed SmartFolderName.sanitize
 //  because `didSet` doesn't fire during initialization. The fix wraps the assignment in
 //  SmartFolderName.sanitize() directly.
 //
-//  This test uses real UserDefaults (lastUsedOrganizationFolderName) with save/restore
-//  in setUp/tearDown so it doesn't pollute other tests.
+//  AMUX-205: uses InMemoryPreferencesProvider instead of mutating
+//  PreferencesManager.shared, so no save/restore boilerplate is needed.
 //
-//  Design doc: .planning/design/backup-manager-run-backup-extraction.md §"Fixed init"
+//  Design doc: .planning/design/PreferencesProviding.md (and predecessor
+//  backup-manager-run-backup-extraction.md §"Fixed init").
 //
 
 import XCTest
@@ -23,17 +24,9 @@ final class BackupManagerOrganizationNameInitTests: BaseBackupManagerTestCase {
     // MARK: - Test fixtures
 
     var mockFileOps: MockFileOperations!
-    private var savedLastUsedName: String? = nil
 
     override func setUp() async throws {
         try await super.setUp()
-
-        // Save current value of lastUsedOrganizationFolderName before resetting.
-        savedLastUsedName = PreferencesManager.shared.lastUsedOrganizationFolderName
-
-        // Reset preferences (clears lastUsedOrganizationFolderName; bookmarks already
-        // cleared by base class).
-        PreferencesManager.shared.resetToDefaults()
 
         mockFileOps = MockFileOperations()
         // Note: bm is not pre-assigned here — each test assigns self.bm with its own
@@ -42,11 +35,7 @@ final class BackupManagerOrganizationNameInitTests: BaseBackupManagerTestCase {
     }
 
     override func tearDown() async throws {
-        // Restore lastUsedOrganizationFolderName.
-        PreferencesManager.shared.lastUsedOrganizationFolderName = savedLastUsedName
-
         mockFileOps = nil
-
         // Base class cancels any in-flight backup via self.bm and restores bookmarks.
         try await super.tearDown()
     }
@@ -60,13 +49,12 @@ final class BackupManagerOrganizationNameInitTests: BaseBackupManagerTestCase {
     /// We verify against SmartFolderName.sanitize("foo/bar"), not the literal "foo_bar",
     /// so the test is robust to future changes in the sanitize implementation.
     func testInit_organizationNameFromPrefs_isSanitized() {
-        // Write a dirty name to UserDefaults (forward slash triggers sanitization).
         let dirtyName = "foo/bar"
-        PreferencesManager.shared.lastUsedOrganizationFolderName = dirtyName
+        let prefs = InMemoryPreferencesProvider(lastUsedOrganizationFolderName: dirtyName)
 
-        // Construct BackupManager — init reads lastUsedOrganizationFolderName.
-        // Assigned to self.bm for tearDown's benefit (cancellation safeguard).
-        self.bm = BackupManager(fileOperations: mockFileOps)
+        // Construct BackupManager — init reads lastUsedOrganizationFolderName from
+        // the injected provider. Assigned to self.bm for tearDown's benefit.
+        self.bm = BackupManager(fileOperations: mockFileOps, preferences: prefs)
 
         let expectedName = SmartFolderName.sanitize(dirtyName)
         XCTAssertEqual(bm.organizationName, expectedName,

--- a/ImageIntactTests/BackupManagerRunBackupTests.swift
+++ b/ImageIntactTests/BackupManagerRunBackupTests.swift
@@ -27,40 +27,31 @@ final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
     var mockFileOps: MockFileOperations!
     var mockPresenter: MockBackupAlertPresenter!
     var mockDiskSpace: MockDiskSpaceChecker!
-
-    // Saved preferences to restore in tearDown.
-    private var savedShowPreflightSummary: Bool = false
+    var prefs: InMemoryPreferencesProvider!
 
     override func setUp() async throws {
         try await super.setUp()
 
-        // Capture original state BEFORE resetting, so tearDown can restore it.
-        savedShowPreflightSummary = PreferencesManager.shared.showPreflightSummary
-
-        // Clear preferences state (bookmarks already cleared by base class).
-        PreferencesManager.shared.resetToDefaults()
-
         mockFileOps = MockFileOperations()
         mockPresenter = MockBackupAlertPresenter()
         mockDiskSpace = MockDiskSpaceChecker()
+        prefs = InMemoryPreferencesProvider()
 
         // Default: disk space check passes with no warnings or errors.
         mockDiskSpace.evaluationResult = (canProceed: true, warnings: [], errors: [])
 
-        // New init params (don't exist yet — compile failure is expected in red phase).
+        // AMUX-205: inject InMemoryPreferencesProvider so this test never touches
+        // PreferencesManager.shared. Per-instance prefs storage means no cross-test bleed.
         bm = BackupManager(
             fileOperations: mockFileOps,
             diskSpaceChecker: mockDiskSpace,
-            backupAlertPresenter: mockPresenter
+            backupAlertPresenter: mockPresenter,
+            preferences: prefs
         )
     }
 
     override func tearDown() async throws {
-        // Reset to defaults first, then restore the captured original value
-        // last — so the restore is not immediately nullified by the reset call.
-        PreferencesManager.shared.resetToDefaults()
-        PreferencesManager.shared.showPreflightSummary = savedShowPreflightSummary
-
+        prefs = nil
         mockPresenter = nil
         mockDiskSpace = nil
         mockFileOps = nil
@@ -214,7 +205,7 @@ final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
         mockPresenter.lowSpaceReturnValue = true
         // Preflight must also be cancelled so runBackup doesn't try to launch the real backup.
         mockPresenter.preflightReturnValue = (proceed: false, showAgain: true)
-        PreferencesManager.shared.showPreflightSummary = true
+        prefs.showPreflightSummary = true
 
         bm.runBackup()
 
@@ -228,7 +219,7 @@ final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
     func testRunBackup_preflight_cancelled_returns() {
         setUpSourceAndDestination()
         mockPresenter.preflightReturnValue = (proceed: false, showAgain: true)
-        PreferencesManager.shared.showPreflightSummary = true
+        prefs.showPreflightSummary = true
 
         bm.runBackup()
 
@@ -242,7 +233,7 @@ final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
     func testRunBackup_preflight_proceedTrue_setsIsProcessing() {
         setUpSourceAndDestination()
         mockPresenter.preflightReturnValue = (proceed: true, showAgain: true)
-        PreferencesManager.shared.showPreflightSummary = true
+        prefs.showPreflightSummary = true
 
         bm.runBackup()
 
@@ -254,13 +245,13 @@ final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
     /// Suppression checkbox behavior: showAgain=false writes false to preferences.
     func testRunBackup_preflight_showAgainFalse_writesPreferenceFalse() {
         setUpSourceAndDestination()
-        PreferencesManager.shared.showPreflightSummary = true
+        prefs.showPreflightSummary = true
         // User unchecks "Show this summary before run" and clicks Start Backup.
         mockPresenter.preflightReturnValue = (proceed: true, showAgain: false)
 
         bm.runBackup()
 
-        XCTAssertFalse(PreferencesManager.shared.showPreflightSummary,
+        XCTAssertFalse(prefs.showPreflightSummary,
                        "showPreflightSummary must be written back as false when showAgain=false")
     }
 
@@ -276,7 +267,7 @@ final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
         mockDiskSpace.evaluationResult = (canProceed: true, warnings: [], errors: [])
         // Cancel at preflight so the backup doesn't actually start.
         mockPresenter.preflightReturnValue = (proceed: false, showAgain: true)
-        PreferencesManager.shared.showPreflightSummary = true
+        prefs.showPreflightSummary = true
 
         // Inject source URL and byte count directly into sourceManager, bypassing
         // prepareSource (which would synchronously reset sourceTotalBytes = 0 and skip
@@ -296,7 +287,7 @@ final class BackupManagerRunBackupTests: BaseBackupManagerTestCase {
     /// entirely and proceeds directly to setting isProcessing = true.
     func testRunBackup_preflightDisabled_noWarnings_setsIsProcessingWithoutAlerts() {
         // Preflight disabled — the presenter should never be asked to show the summary.
-        PreferencesManager.shared.showPreflightSummary = false
+        prefs.showPreflightSummary = false
 
         // Disk space defaults (set in setUp): canProceed = true, no warnings, no errors.
         setUpSourceAndDestination()

--- a/ImageIntactTests/BackupManagerSetDestinationTests.swift
+++ b/ImageIntactTests/BackupManagerSetDestinationTests.swift
@@ -21,24 +21,26 @@ final class BackupManagerSetDestinationTests: XCTestCase {
     var mockFileOps: MockFileOperations!
     var mockPresenter: MockDestinationAlertPresenter!
     var backupManager: BackupManager!
+    var prefs: InMemoryPreferencesProvider!
 
     override func setUp() async throws {
         try await super.setUp()
 
-        // Clear bookmark and preferences state so init doesn't restore stale data.
+        // Clear bookmark state so init doesn't restore stale data.
         UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
         for key in BookmarkManager.destinationKeys {
             UserDefaults.standard.removeObject(forKey: key)
         }
-        PreferencesManager.shared.resetToDefaults()
 
         mockFileOps = MockFileOperations()
         mockPresenter = MockDestinationAlertPresenter()
+        prefs = InMemoryPreferencesProvider()
 
-        // New init param (doesn't exist yet — compile failure is expected).
+        // AMUX-205: inject prefs so this test never mutates PreferencesManager.shared.
         backupManager = BackupManager(
             fileOperations: mockFileOps,
-            destinationAlertPresenter: mockPresenter
+            destinationAlertPresenter: mockPresenter,
+            preferences: prefs
         )
     }
 
@@ -47,11 +49,11 @@ final class BackupManagerSetDestinationTests: XCTestCase {
         for key in BookmarkManager.destinationKeys {
             UserDefaults.standard.removeObject(forKey: key)
         }
-        PreferencesManager.shared.resetToDefaults()
 
         backupManager = nil
         mockPresenter = nil
         mockFileOps = nil
+        prefs = nil
 
         try await super.tearDown()
     }

--- a/ImageIntactTests/Mocks/InMemoryPreferencesProvider.swift
+++ b/ImageIntactTests/Mocks/InMemoryPreferencesProvider.swift
@@ -1,0 +1,72 @@
+//
+//  InMemoryPreferencesProvider.swift
+//  ImageIntactTests
+//
+//  In-memory PreferencesProviding for tests. Holds values in plain stored
+//  properties — never touches UserDefaults. Lets BackupManager tests run in
+//  parallel without bleeding shared state across test methods.
+//
+
+import Foundation
+@testable import ImageIntact
+
+/// Test double for `PreferencesProviding`. Each instance owns its own storage,
+/// so multiple BackupManager tests can hold independent preference state.
+final class InMemoryPreferencesProvider: PreferencesProviding {
+    var enableSmartDuplicateDetection: Bool
+    var lastUsedOrganizationFolderName: String?
+    var restoreLastSession: Bool
+    var showPreflightSummary: Bool
+    var excludeCacheFiles: Bool
+    var skipHiddenFiles: Bool
+    var showNotificationOnComplete: Bool
+    var trashSourceAfterBackup: Bool
+    var largeBackupFileThreshold: Int
+    var largeBackupSizeThresholdGB: Double
+    var confirmLargeBackups: Bool
+    var skipLargeBackupWarning: Bool
+
+    /// Names recorded via `addRecentOrganizationFolderName(_:)`, most-recent first.
+    /// Exposed so tests can assert the recorded order without reaching into UserDefaults.
+    private(set) var recentOrganizationFolderNames: [String] = []
+
+    init(
+        enableSmartDuplicateDetection: Bool = false,
+        lastUsedOrganizationFolderName: String? = nil,
+        restoreLastSession: Bool = true,
+        showPreflightSummary: Bool = false,
+        excludeCacheFiles: Bool = true,
+        skipHiddenFiles: Bool = true,
+        showNotificationOnComplete: Bool = true,
+        trashSourceAfterBackup: Bool = false,
+        largeBackupFileThreshold: Int = 1000,
+        largeBackupSizeThresholdGB: Double = 10.0,
+        confirmLargeBackups: Bool = true,
+        skipLargeBackupWarning: Bool = false
+    ) {
+        self.enableSmartDuplicateDetection = enableSmartDuplicateDetection
+        self.lastUsedOrganizationFolderName = lastUsedOrganizationFolderName
+        self.restoreLastSession = restoreLastSession
+        self.showPreflightSummary = showPreflightSummary
+        self.excludeCacheFiles = excludeCacheFiles
+        self.skipHiddenFiles = skipHiddenFiles
+        self.showNotificationOnComplete = showNotificationOnComplete
+        self.trashSourceAfterBackup = trashSourceAfterBackup
+        self.largeBackupFileThreshold = largeBackupFileThreshold
+        self.largeBackupSizeThresholdGB = largeBackupSizeThresholdGB
+        self.confirmLargeBackups = confirmLargeBackups
+        self.skipLargeBackupWarning = skipLargeBackupWarning
+    }
+
+    func addRecentOrganizationFolderName(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        recentOrganizationFolderNames.removeAll { $0 == trimmed }
+        recentOrganizationFolderNames.insert(trimmed, at: 0)
+
+        if recentOrganizationFolderNames.count > 10 {
+            recentOrganizationFolderNames = Array(recentOrganizationFolderNames.prefix(10))
+        }
+    }
+}

--- a/ImageIntactTests/Mocks/InMemoryPreferencesProvider.swift
+++ b/ImageIntactTests/Mocks/InMemoryPreferencesProvider.swift
@@ -13,10 +13,11 @@ import Foundation
 /// Test double for `PreferencesProviding`. Each instance owns its own storage,
 /// so multiple BackupManager tests can hold independent preference state.
 ///
-/// Marked `@MainActor` to match BackupManager's isolation — all production reads
-/// and writes through this protocol come from a `@MainActor` `BackupManager`,
-/// so no cross-actor synchronization is required and TSAN stays clean.
-@MainActor
+/// Not annotated `@MainActor` (to match the unisolated `PreferencesProviding`
+/// protocol and `PreferencesManager`, which is itself not MainActor-isolated).
+/// In practice every caller is MainActor-isolated — `BackupManager` is
+/// `@MainActor` and all of these tests are `@MainActor` — so the unsynchronized
+/// `var` properties are safe and TSAN stays clean.
 final class InMemoryPreferencesProvider: PreferencesProviding {
     var enableSmartDuplicateDetection: Bool
     var lastUsedOrganizationFolderName: String?

--- a/ImageIntactTests/Mocks/InMemoryPreferencesProvider.swift
+++ b/ImageIntactTests/Mocks/InMemoryPreferencesProvider.swift
@@ -12,6 +12,11 @@ import Foundation
 
 /// Test double for `PreferencesProviding`. Each instance owns its own storage,
 /// so multiple BackupManager tests can hold independent preference state.
+///
+/// Marked `@MainActor` to match BackupManager's isolation — all production reads
+/// and writes through this protocol come from a `@MainActor` `BackupManager`,
+/// so no cross-actor synchronization is required and TSAN stays clean.
+@MainActor
 final class InMemoryPreferencesProvider: PreferencesProviding {
     var enableSmartDuplicateDetection: Bool
     var lastUsedOrganizationFolderName: String?

--- a/ImageIntactTests/PreferencesProvidingTests.swift
+++ b/ImageIntactTests/PreferencesProvidingTests.swift
@@ -188,6 +188,79 @@ final class PreferencesProvidingTests: XCTestCase {
                        "runBackup must record organizationName via preferences.addRecentOrganizationFolderName")
     }
 
+    /// buildPreflightSummary must read excludeCacheFiles + skipHiddenFiles from
+    /// the injected provider. We observe the preflight summary the mock
+    /// presenter receives and verify the fields match what we set on `prefs`.
+    func testBackupManager_runBackup_preflight_readsExcludeCacheAndSkipHiddenFromInjectedPreferences() {
+        let prefs = InMemoryPreferencesProvider(
+            showPreflightSummary: true,
+            excludeCacheFiles: false,
+            skipHiddenFiles: false
+        )
+        let mockDisk = MockDiskSpaceChecker()
+        mockDisk.evaluationResult = (canProceed: true, warnings: [], errors: [])
+        let mockPresenter = MockBackupAlertPresenter()
+        // Cancel at preflight so the backup doesn't try to actually run.
+        mockPresenter.preflightReturnValue = (proceed: false, showAgain: true)
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            diskSpaceChecker: mockDisk,
+            backupAlertPresenter: mockPresenter,
+            preferences: prefs
+        )
+
+        bm.sourceManager.sourceURL = URL(fileURLWithPath: "/Volumes/CardA/DCIM")
+        bm.setDestination(URL(fileURLWithPath: "/Volumes/BackupDrive"), at: 0)
+
+        bm.runBackup()
+
+        XCTAssertEqual(mockPresenter.presentPreflightCalls.count, 1,
+                       "Preflight summary must be presented when showPreflightSummary=true")
+        let summary = mockPresenter.presentPreflightCalls.first
+        XCTAssertEqual(summary?.excludeCacheFiles, false,
+                       "buildPreflightSummary must read excludeCacheFiles from preferences (set false on the injected provider)")
+        XCTAssertEqual(summary?.skipHiddenFiles, false,
+                       "buildPreflightSummary must read skipHiddenFiles from preferences (set false on the injected provider)")
+    }
+
+    /// runBackup with `restoreLastSession=false` must NOT call
+    /// destinationManager.loadFromSession at init. We can't easily mock the
+    /// destinationManager, but we can verify the observable result: with no
+    /// bookmark keys set and restoreLastSession=false, init takes the
+    /// `initializeEmpty()` branch and ends up with exactly one empty slot.
+    /// With restoreLastSession=true and no bookmarks, init takes
+    /// loadFromSession() — which also ends up with zero/empty items because
+    /// there's nothing to load. Both branches converge to "no real
+    /// destinations". The test asserts the convergent outcome, which is the
+    /// only externally observable shape without a destinationManager mock.
+    func testBackupManager_init_restoreLastSession_false_initializesEmpty() {
+        // Clear any bookmark state from prior sessions (defensive — the test
+        // base classes also do this, but PreferencesProvidingTests is a
+        // plain XCTestCase).
+        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        for key in BookmarkManager.destinationKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        let prefs = InMemoryPreferencesProvider(restoreLastSession: false)
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        // initializeEmpty() seeds exactly one empty DestinationItem.
+        // If init had wrongly hardcoded `PreferencesManager.shared.restoreLastSession`,
+        // it might still load from session — but with bookmarks cleared, the
+        // observable result is identical. The strongest signal we can get
+        // without a destinationManager mock is that the resulting state is
+        // the "no destinations" shape.
+        XCTAssertEqual(bm.destinationItems.count, 1,
+                       "restoreLastSession=false must take the initializeEmpty branch with one empty slot")
+        XCTAssertNil(bm.destinationItems.first?.url,
+                     "initializeEmpty slot must have nil URL")
+    }
+
     /// runBackup with empty organizationName must NOT touch the recent list or
     /// `lastUsedOrganizationFolderName`.
     func testBackupManager_runBackup_emptyOrganizationName_leavesRecentEmpty() {

--- a/ImageIntactTests/PreferencesProvidingTests.swift
+++ b/ImageIntactTests/PreferencesProvidingTests.swift
@@ -261,6 +261,212 @@ final class PreferencesProvidingTests: XCTestCase {
                      "initializeEmpty slot must have nil URL")
     }
 
+    // MARK: - BackupManager DI — handleBackupCompletion reads
+
+    /// handleBackupCompletion must read `showNotificationOnComplete` from the
+    /// injected provider. With true, the notification service receives a
+    /// completion notification; with false it does not.
+    func testBackupManager_handleBackupCompletion_showNotificationOnCompleteTrue_sendsNotification() async {
+        let prefs = InMemoryPreferencesProvider(showNotificationOnComplete: true)
+        let mockNotifier = MockNotificationService()
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            notificationService: mockNotifier,
+            preferences: prefs
+        )
+
+        await bm.handleBackupCompletion(destinations: [URL(fileURLWithPath: "/Volumes/BackupDrive")])
+
+        XCTAssertEqual(mockNotifier.sentNotifications.count, 1,
+                       "handleBackupCompletion must send a notification when showNotificationOnComplete=true")
+    }
+
+    func testBackupManager_handleBackupCompletion_showNotificationOnCompleteFalse_noNotification() async {
+        let prefs = InMemoryPreferencesProvider(showNotificationOnComplete: false)
+        let mockNotifier = MockNotificationService()
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            notificationService: mockNotifier,
+            preferences: prefs
+        )
+
+        await bm.handleBackupCompletion(destinations: [URL(fileURLWithPath: "/Volumes/BackupDrive")])
+
+        XCTAssertEqual(mockNotifier.sentNotifications.count, 0,
+                       "handleBackupCompletion must NOT send a notification when showNotificationOnComplete=false")
+    }
+
+    /// handleBackupCompletion must read `trashSourceAfterBackup` from the
+    /// injected provider. With true (and no failed files + a source URL set),
+    /// showTrashConfirmation flips to true.
+    func testBackupManager_handleBackupCompletion_trashSourceAfterBackupTrue_showsTrashConfirmation() async {
+        let prefs = InMemoryPreferencesProvider(trashSourceAfterBackup: true)
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        bm.sourceManager.sourceURL = URL(fileURLWithPath: "/Volumes/CardA/DCIM")
+        // failedFiles is empty by default.
+
+        await bm.handleBackupCompletion(destinations: [URL(fileURLWithPath: "/Volumes/BackupDrive")])
+
+        XCTAssertTrue(bm.showTrashConfirmation,
+                      "handleBackupCompletion must flip showTrashConfirmation when trashSourceAfterBackup=true and backup succeeded")
+    }
+
+    func testBackupManager_handleBackupCompletion_trashSourceAfterBackupFalse_noTrashConfirmation() async {
+        let prefs = InMemoryPreferencesProvider(trashSourceAfterBackup: false)
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        bm.sourceManager.sourceURL = URL(fileURLWithPath: "/Volumes/CardA/DCIM")
+
+        await bm.handleBackupCompletion(destinations: [URL(fileURLWithPath: "/Volumes/BackupDrive")])
+
+        XCTAssertFalse(bm.showTrashConfirmation,
+                       "handleBackupCompletion must NOT flip showTrashConfirmation when trashSourceAfterBackup=false")
+    }
+
+    // MARK: - BackupManager DI — checkForLargeBackupAndWait reads
+
+    /// `confirmLargeBackups=false` → checkForLargeBackupAndWait returns true
+    /// immediately without computing thresholds. This is a pure read-gate test.
+    func testBackupManager_checkLargeBackup_confirmLargeBackupsFalse_returnsTrueImmediately() async {
+        let prefs = InMemoryPreferencesProvider(
+            largeBackupFileThreshold: 0,                   // would trigger if not gated
+            largeBackupSizeThresholdGB: 0,                 // would trigger if not gated
+            confirmLargeBackups: false,                    // gate: skip the warning entirely
+            skipLargeBackupWarning: false
+        )
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        let result = await bm.checkForLargeBackupAndWait(
+            source: URL(fileURLWithPath: "/Volumes/CardA/DCIM"),
+            destinations: [URL(fileURLWithPath: "/Volumes/BackupDrive")],
+            manifest: [FileManifestEntry(relativePath: "a.jpg", sourceURL: URL(fileURLWithPath: "/a.jpg"), checksum: "x", size: 100)]
+        )
+
+        XCTAssertTrue(result,
+                      "checkForLargeBackupAndWait must return true (proceed) when confirmLargeBackups=false, regardless of size")
+        XCTAssertFalse(bm.showLargeBackupConfirmation,
+                       "showLargeBackupConfirmation must stay false when confirmLargeBackups=false")
+    }
+
+    /// `skipLargeBackupWarning=true` → checkForLargeBackupAndWait returns true
+    /// immediately. Verifies the read path (the write path is covered by
+    /// `testBackupManager_respondToLargeBackup_dontShowAgain_writesToInjectedPreferences`).
+    func testBackupManager_checkLargeBackup_skipLargeBackupWarningTrue_returnsTrueImmediately() async {
+        let prefs = InMemoryPreferencesProvider(
+            largeBackupFileThreshold: 0,
+            largeBackupSizeThresholdGB: 0,
+            confirmLargeBackups: true,
+            skipLargeBackupWarning: true                   // gate: user opted out previously
+        )
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        let result = await bm.checkForLargeBackupAndWait(
+            source: URL(fileURLWithPath: "/Volumes/CardA/DCIM"),
+            destinations: [URL(fileURLWithPath: "/Volumes/BackupDrive")],
+            manifest: [FileManifestEntry(relativePath: "a.jpg", sourceURL: URL(fileURLWithPath: "/a.jpg"), checksum: "x", size: 100)]
+        )
+
+        XCTAssertTrue(result,
+                      "checkForLargeBackupAndWait must return true (proceed) when skipLargeBackupWarning=true")
+        XCTAssertFalse(bm.showLargeBackupConfirmation,
+                       "showLargeBackupConfirmation must stay false when skipLargeBackupWarning=true")
+    }
+
+    /// Manifest below both thresholds → checkForLargeBackupAndWait returns
+    /// true without showing the warning. Verifies the file-count + GB
+    /// threshold reads from the injected provider.
+    func testBackupManager_checkLargeBackup_belowThresholds_returnsTrueWithoutWarning() async {
+        let prefs = InMemoryPreferencesProvider(
+            largeBackupFileThreshold: 1000,
+            largeBackupSizeThresholdGB: 10.0,
+            confirmLargeBackups: true,
+            skipLargeBackupWarning: false
+        )
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        // Manifest with 1 file, 100 bytes — well below both thresholds.
+        let smallManifest = [FileManifestEntry(
+            relativePath: "a.jpg",
+            sourceURL: URL(fileURLWithPath: "/a.jpg"),
+            checksum: "x",
+            size: 100
+        )]
+
+        let result = await bm.checkForLargeBackupAndWait(
+            source: URL(fileURLWithPath: "/Volumes/CardA/DCIM"),
+            destinations: [URL(fileURLWithPath: "/Volumes/BackupDrive")],
+            manifest: smallManifest
+        )
+
+        XCTAssertTrue(result,
+                      "checkForLargeBackupAndWait must return true when manifest is below file+size thresholds")
+        XCTAssertFalse(bm.showLargeBackupConfirmation,
+                       "showLargeBackupConfirmation must stay false when manifest is below thresholds")
+    }
+
+    /// Manifest above the file-count threshold → checkForLargeBackupAndWait
+    /// suspends on a continuation that respondToLargeBackupConfirmation
+    /// resumes. Reaching the continuation at all (and getting back the value
+    /// the responder supplied) proves the largeBackupFileThreshold read was
+    /// taken from the injected provider.
+    func testBackupManager_checkLargeBackup_aboveFileThreshold_blocksOnContinuation() async {
+        let prefs = InMemoryPreferencesProvider(
+            largeBackupFileThreshold: 1,                   // tiny — manifest of 2 files exceeds
+            largeBackupSizeThresholdGB: 1000.0,            // huge — won't trigger via bytes
+            confirmLargeBackups: true,
+            skipLargeBackupWarning: false
+        )
+        let bm = BackupManager(fileOperations: MockFileOperations(), preferences: prefs)
+        let manifest = [
+            FileManifestEntry(relativePath: "a.jpg", sourceURL: URL(fileURLWithPath: "/a.jpg"), checksum: "x", size: 100),
+            FileManifestEntry(relativePath: "b.jpg", sourceURL: URL(fileURLWithPath: "/b.jpg"), checksum: "y", size: 100),
+        ]
+
+        // checkForLargeBackupAndWait suspends on a continuation; resume it
+        // from a separate Task once `showLargeBackupConfirmation` flips.
+        Task { @MainActor in
+            for _ in 0..<100 {
+                if bm.showLargeBackupConfirmation {
+                    bm.respondToLargeBackupConfirmation(shouldContinue: false, dontShowAgain: false)
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 1_000_000)
+            }
+        }
+
+        let result = await bm.checkForLargeBackupAndWait(
+            source: URL(fileURLWithPath: "/Volumes/CardA/DCIM"),
+            destinations: [URL(fileURLWithPath: "/Volumes/BackupDrive")],
+            manifest: manifest
+        )
+
+        XCTAssertFalse(result,
+                       "checkForLargeBackupAndWait must return what the responder supplied (false). Reaching the continuation proves the file-count threshold read fired.")
+    }
+
     /// runBackup with empty organizationName must NOT touch the recent list or
     /// `lastUsedOrganizationFolderName`.
     func testBackupManager_runBackup_emptyOrganizationName_leavesRecentEmpty() {

--- a/ImageIntactTests/PreferencesProvidingTests.swift
+++ b/ImageIntactTests/PreferencesProvidingTests.swift
@@ -123,4 +123,94 @@ final class PreferencesProvidingTests: XCTestCase {
         // Reading is harmless and doesn't mutate UserDefaults.
         _ = prefs.confirmLargeBackups
     }
+
+    // MARK: - BackupManager DI — writes back through injected preferences
+
+    /// `respondToLargeBackupConfirmation(dontShowAgain: true)` must write
+    /// `skipLargeBackupWarning = true` to the injected provider, not to
+    /// `PreferencesManager.shared`.
+    func testBackupManager_respondToLargeBackup_dontShowAgain_writesToInjectedPreferences() {
+        let prefs = InMemoryPreferencesProvider(skipLargeBackupWarning: false)
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        bm.respondToLargeBackupConfirmation(shouldContinue: false, dontShowAgain: true)
+
+        XCTAssertTrue(prefs.skipLargeBackupWarning,
+                      "respondToLargeBackupConfirmation must persist dontShowAgain through preferences.skipLargeBackupWarning")
+    }
+
+    /// `respondToLargeBackupConfirmation(dontShowAgain: false)` must NOT
+    /// touch `skipLargeBackupWarning`.
+    func testBackupManager_respondToLargeBackup_dontShowAgainFalse_leavesSkipWarning() {
+        let prefs = InMemoryPreferencesProvider(skipLargeBackupWarning: false)
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        bm.respondToLargeBackupConfirmation(shouldContinue: true, dontShowAgain: false)
+
+        XCTAssertFalse(prefs.skipLargeBackupWarning,
+                       "respondToLargeBackupConfirmation must leave skipLargeBackupWarning unchanged when dontShowAgain=false")
+    }
+
+    /// runBackup must record the organizationName via the injected provider's
+    /// `lastUsedOrganizationFolderName` and `addRecentOrganizationFolderName`.
+    /// We can't drive runBackup to completion from a unit test (it spawns the
+    /// async backup pipeline), but the persist-name block runs synchronously
+    /// before that point, so a runBackup() call is enough to observe the writes.
+    func testBackupManager_runBackup_recordsOrganizationNameInPreferences() {
+        let prefs = InMemoryPreferencesProvider()
+        let mockDisk = MockDiskSpaceChecker()
+        mockDisk.evaluationResult = (canProceed: true, warnings: [], errors: [])
+        let mockPresenter = MockBackupAlertPresenter()
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            diskSpaceChecker: mockDisk,
+            backupAlertPresenter: mockPresenter,
+            preferences: prefs
+        )
+
+        // Set a source + destination so runBackup can reach the persist-name block.
+        bm.sourceManager.sourceURL = URL(fileURLWithPath: "/Volumes/CardA/DCIM")
+        bm.setDestination(URL(fileURLWithPath: "/Volumes/BackupDrive"), at: 0)
+        bm.organizationName = "MyShoot"
+
+        bm.runBackup()
+
+        XCTAssertEqual(prefs.lastUsedOrganizationFolderName, "MyShoot",
+                       "runBackup must persist organizationName via preferences.lastUsedOrganizationFolderName")
+        XCTAssertEqual(prefs.recentOrganizationFolderNames.first, "MyShoot",
+                       "runBackup must record organizationName via preferences.addRecentOrganizationFolderName")
+    }
+
+    /// runBackup with empty organizationName must NOT touch the recent list or
+    /// `lastUsedOrganizationFolderName`.
+    func testBackupManager_runBackup_emptyOrganizationName_leavesRecentEmpty() {
+        let prefs = InMemoryPreferencesProvider(lastUsedOrganizationFolderName: "PriorValue")
+        let mockDisk = MockDiskSpaceChecker()
+        mockDisk.evaluationResult = (canProceed: true, warnings: [], errors: [])
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            diskSpaceChecker: mockDisk,
+            backupAlertPresenter: MockBackupAlertPresenter(),
+            preferences: prefs
+        )
+
+        bm.sourceManager.sourceURL = URL(fileURLWithPath: "/Volumes/CardA/DCIM")
+        bm.setDestination(URL(fileURLWithPath: "/Volumes/BackupDrive"), at: 0)
+        bm.organizationName = ""
+
+        bm.runBackup()
+
+        XCTAssertEqual(prefs.lastUsedOrganizationFolderName, "PriorValue",
+                       "runBackup with empty organizationName must not overwrite lastUsedOrganizationFolderName")
+        XCTAssertTrue(prefs.recentOrganizationFolderNames.isEmpty,
+                      "runBackup with empty organizationName must not call addRecentOrganizationFolderName")
+    }
 }

--- a/ImageIntactTests/PreferencesProvidingTests.swift
+++ b/ImageIntactTests/PreferencesProvidingTests.swift
@@ -1,0 +1,126 @@
+//
+//  PreferencesProvidingTests.swift
+//  ImageIntactTests
+//
+//  TDD red-phase tests for the PreferencesProviding protocol (AMUX-205).
+//
+//  These tests reference `PreferencesProviding` (not yet defined),
+//  `InMemoryPreferencesProvider` (not yet defined), and the new
+//  `BackupManager(preferences:)` init parameter (not yet added) — compile
+//  failure here IS the red-phase signal.
+//
+//  Goal: BackupManager reads/writes its preferences through an injected
+//  `PreferencesProviding`, never reaching into `UserDefaults.standard`. That
+//  lets tests use a per-instance in-memory provider, eliminates shared-state
+//  bleed across tests, and removes the bookmark capture/restore boilerplate
+//  in BaseBackupManagerTestCase.
+//
+
+import XCTest
+@testable import ImageIntact
+
+@MainActor
+final class PreferencesProvidingTests: XCTestCase {
+
+    // MARK: - Protocol contract — read/write surface
+
+    /// The in-memory provider holds and returns whatever was written to each
+    /// settable property — no UserDefaults round-trip.
+    func testInMemoryProvider_readWriteRoundTrip() {
+        let prefs = InMemoryPreferencesProvider()
+
+        prefs.showPreflightSummary = true
+        XCTAssertTrue(prefs.showPreflightSummary)
+
+        prefs.lastUsedOrganizationFolderName = "MyShoot"
+        XCTAssertEqual(prefs.lastUsedOrganizationFolderName, "MyShoot")
+
+        prefs.skipLargeBackupWarning = true
+        XCTAssertTrue(prefs.skipLargeBackupWarning)
+    }
+
+    /// Constructor defaults match the production PreferencesManager defaults,
+    /// so tests that don't override get realistic behavior.
+    func testInMemoryProvider_defaultsMatchProductionDefaults() {
+        let prefs = InMemoryPreferencesProvider()
+
+        XCTAssertFalse(prefs.enableSmartDuplicateDetection)
+        XCTAssertNil(prefs.lastUsedOrganizationFolderName)
+        XCTAssertTrue(prefs.restoreLastSession)
+        XCTAssertFalse(prefs.showPreflightSummary)
+        XCTAssertTrue(prefs.excludeCacheFiles)
+        XCTAssertTrue(prefs.skipHiddenFiles)
+        XCTAssertTrue(prefs.showNotificationOnComplete)
+        XCTAssertFalse(prefs.trashSourceAfterBackup)
+        XCTAssertEqual(prefs.largeBackupFileThreshold, 1000)
+        XCTAssertEqual(prefs.largeBackupSizeThresholdGB, 10.0)
+        XCTAssertTrue(prefs.confirmLargeBackups)
+        XCTAssertFalse(prefs.skipLargeBackupWarning)
+    }
+
+    /// `addRecentOrganizationFolderName` matches PreferencesManager semantics:
+    /// most-recent first, no duplicates, capped at 10.
+    func testInMemoryProvider_addRecentOrganizationFolderName_recentFirstNoDupes() {
+        let prefs = InMemoryPreferencesProvider()
+
+        prefs.addRecentOrganizationFolderName("Alpha")
+        prefs.addRecentOrganizationFolderName("Beta")
+        prefs.addRecentOrganizationFolderName("Alpha") // duplicate -> moves to top
+
+        XCTAssertEqual(prefs.recentOrganizationFolderNames, ["Alpha", "Beta"])
+    }
+
+    /// Empty / whitespace-only names are ignored — matches PreferencesManager.
+    func testInMemoryProvider_addRecentOrganizationFolderName_ignoresEmpty() {
+        let prefs = InMemoryPreferencesProvider()
+
+        prefs.addRecentOrganizationFolderName("")
+        prefs.addRecentOrganizationFolderName("   ")
+
+        XCTAssertTrue(prefs.recentOrganizationFolderNames.isEmpty)
+    }
+
+    // MARK: - BackupManager DI — uses injected preferences
+
+    /// BackupManager(preferences:) reads `lastUsedOrganizationFolderName` from
+    /// the injected provider at init time, not from PreferencesManager.shared.
+    /// Red-phase signal: this init signature doesn't exist yet.
+    func testBackupManager_init_readsLastUsedNameFromInjectedPreferences() {
+        let prefs = InMemoryPreferencesProvider(lastUsedOrganizationFolderName: "InjectedShoot")
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        // The expected value is sanitized in BackupManager.init via SmartFolderName.sanitize.
+        // "InjectedShoot" has no special chars so it stays unchanged.
+        XCTAssertEqual(bm.organizationName, "InjectedShoot")
+    }
+
+    /// BackupManager.enableDuplicateDetection forwards to the injected
+    /// provider, not PreferencesManager.shared.
+    func testBackupManager_enableDuplicateDetection_readsFromInjectedPreferences() {
+        let prefs = InMemoryPreferencesProvider(enableSmartDuplicateDetection: true)
+
+        let bm = BackupManager(
+            fileOperations: MockFileOperations(),
+            preferences: prefs
+        )
+
+        XCTAssertTrue(bm.enableDuplicateDetection)
+
+        prefs.enableSmartDuplicateDetection = false
+        XCTAssertFalse(bm.enableDuplicateDetection,
+                       "BackupManager must read live state from the injected provider")
+    }
+
+    /// PreferencesManager.shared conforms to PreferencesProviding so production
+    /// code keeps working with the default init argument.
+    func testPreferencesManagerShared_conformsToPreferencesProviding() {
+        let prefs: PreferencesProviding = PreferencesManager.shared
+        // Touch one property to force the existential to resolve at runtime.
+        // Reading is harmless and doesn't mutate UserDefaults.
+        _ = prefs.confirmLargeBackups
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts a `PreferencesProviding` protocol for the prefs surface `BackupManager` depends on, and injects it via `BackupManager(preferences:)` (defaults to `PreferencesManager.shared` for production).
- Adds `InMemoryPreferencesProvider` so tests use per-instance storage instead of mutating `PreferencesManager.shared` + `UserDefaults.standard`.
- Drops per-test `savedShowPreflightSummary` / `savedLastUsedName` save/restore and `PreferencesManager.shared.resetToDefaults()` calls in 5 `BackupManager*Tests`. `BaseBackupManagerTestCase`'s `BookmarkManager` capture/restore is retained — `BookmarkManager` still touches `UserDefaults` directly and is out of scope.
- Brings the orphan root-level `ImageIntact.xctestplan` (`parallelizable: false`) in line with the live plans (`TestPlans/Fast.xctestplan` and `TestPlans/Comprehensive.xctestplan` already have `parallelizable: true`).

Addresses the architecture reviewer's recurring HIGH on PR #119 (5+ panel rounds) and AMUX-15 follow-ups.

## Protocol surface (audit of `BackupManager.swift` + `BackupManagerQueueIntegration.swift`)

- `enableSmartDuplicateDetection`
- `lastUsedOrganizationFolderName` (get/set)
- `restoreLastSession`
- `showPreflightSummary` (get/set)
- `excludeCacheFiles`, `skipHiddenFiles`
- `showNotificationOnComplete`, `trashSourceAfterBackup`
- `largeBackupFileThreshold`, `largeBackupSizeThresholdGB`
- `confirmLargeBackups`
- `skipLargeBackupWarning` (get/set)
- `addRecentOrganizationFolderName(_:)`

## Out of scope (separate follow-ups if worth doing)

- `PreferencesManager.shared` call sites outside `BackupManager.*` (e.g. `BackupPreset`, `ApplicationLogger`).
- Other shared singletons the panel review flagged (`EventLogger.shared`, `SleepPrevention.shared`, `ChecksumBufferPool.shared`, `ApplicationLogger.shared`).

## Test plan

- [x] **New tests** — `PreferencesProvidingTests` (7 cases) covers the protocol contract, BackupManager DI, and `PreferencesManager.shared` conformance.
- [x] **Refactored existing tests** — `BackupManagerCancelTests`, `BackupManagerCleanupTests`, `BackupManagerOrganizationNameInitTests`, `BackupManagerRunBackupTests`, `BackupManagerSetDestinationTests` all inject `InMemoryPreferencesProvider`.
- [x] **Full suite parity** — 502/513 passed (502 = 495 baseline + 7 new). Same 11 pre-existing fails (10 deterministic in `ManifestBuilderFilterTests` + `SubdirectoryTraversalTests`, 1 flake in `BackupCoordinatorTests.testProgressTracking`). **Zero AMUX-205-introduced regressions.**
- [ ] **Panel review** — running `~/.claude/tools/review pr` next.

## Pre-existing baseline state (not introduced by this PR)

- 10 deterministic failures in `ManifestBuilderFilterTests` + `SubdirectoryTraversalTests` — exist on `origin/main` `cc2f59f` and reproduce on retry. Will file as an incidentals ticket.
- `BackupCoordinatorTests.testProgressTracking` flakes with a 15s expectation timeout under load; passes on retry.
- `BackupManager.swift` and `BackupManagerQueueIntegration.swift` already exceed the workspace 500-line soft-limit (671 / 751 lines on `main`). This PR adds ~3 net lines to each; not the cause of the overage. Will file as an incidentals ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)