### PR TITLE
fix: resolve symlinks when computing manifest relative paths (AMUX-228)

### DIFF
--- a/ImageIntact/Models/ManifestBuilder.swift
+++ b/ImageIntact/Models/ManifestBuilder.swift
@@ -71,6 +71,28 @@ actor ManifestBuilder {
 
     init() {}
 
+    // MARK: - Path canonicalization
+
+    /// Resolve `url` to its canonical absolute path via `realpath(3)`.
+    ///
+    /// On macOS this returns the form that `FileManager`'s directory
+    /// enumerator yields for child URLs (e.g. `/private/var/...` for paths
+    /// under the system temp dir), letting us compare with `hasPrefix` and
+    /// strip a known prefix length deterministically.
+    ///
+    /// On `realpath` failure (e.g. the path doesn't exist), falls back to
+    /// `url.path`. Callers should be prepared for the prefix-strip to fail
+    /// for URLs outside the canonical source tree.
+    static func canonicalPath(of url: URL) -> String {
+        var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
+        return url.withUnsafeFileSystemRepresentation { ptr -> String in
+            guard let ptr = ptr, realpath(ptr, &buf) != nil else {
+                return url.path
+            }
+            return String(cString: buf)
+        }
+    }
+
     // MARK: - Helper Methods
 
     /// Check if a file or directory should be excluded as a cache/temporary file
@@ -187,18 +209,14 @@ actor ManifestBuilder {
         var skippedByFilter = 0
 
         // macOS symlinks `/var` → `/private/var` (and `/tmp` → `/private/tmp`).
-        // FileManager.default.temporaryDirectory hands back the `/var/...` form,
+        // `FileManager.default.temporaryDirectory` hands back the `/var/...` form,
         // but `enumerator.nextObject()` returns each child with the resolved
-        // `/private/var/...` form. A plain string-strip of
-        // `source.path + "/"` against `url.path` then matches the suffix after
-        // `/private`, producing garbled relativePaths like `/privatefile.jpg`.
-        // `URL.resolvingSymlinksInPath()` does the reverse — it strips `/private`
-        // out — so resolving BOTH source AND each enumerated url puts them in
-        // the same `/var/...` form and the prefix-strip works. Production
-        // user-picked URLs typically don't traverse symlinks, so this is a
-        // no-op there; the fix is for test correctness (temp dirs) and any
-        // production path that happens to traverse `/tmp` or `/var`.
-        let resolvedSourcePrefix = source.resolvingSymlinksInPath().path + "/"
+        // `/private/var/...` form. `URL.resolvingSymlinksInPath()` doesn't help
+        // here — it strips `/private` rather than adding it. `realpath(3)` does:
+        // it follows symlinks AND returns the canonical absolute path that
+        // matches the enumerator's children. Compute it once outside the loop
+        // to avoid per-file filesystem I/O.
+        let canonicalSourcePrefix = Self.canonicalPath(of: source) + "/"
 
         // Collect files first
         while let url = enumerator.nextObject() as? URL {
@@ -264,8 +282,28 @@ actor ManifestBuilder {
                     ApplicationLogger.shared.debug("Found video: \(url.lastPathComponent)", category: .fileSystem)
                 }
 
-                let relativePath = url.resolvingSymlinksInPath().path
-                    .replacingOccurrences(of: resolvedSourcePrefix, with: "")
+                // Strip the canonical source prefix to get the relativePath.
+                // `replacingOccurrences` would replace ALL substring matches —
+                // a problem if any segment of the absolute path happens to
+                // repeat the source path (e.g. `/tmp/foo/tmp/foo/x.jpg` under
+                // source `/tmp/foo`). `hasPrefix` + `dropFirst(count)` strips
+                // only the prefix. If the url doesn't start with the canonical
+                // source (e.g. the enumerator yielded a path outside the source
+                // tree via a followed symlink), skip and log — storing an
+                // absolute path as a "relative" manifest entry would silently
+                // duplicate or break the destination layout.
+                let urlPath = url.path
+                let relativePath: String
+                if urlPath.hasPrefix(canonicalSourcePrefix) {
+                    relativePath = String(urlPath.dropFirst(canonicalSourcePrefix.count))
+                } else {
+                    ApplicationLogger.shared.warning(
+                        "ManifestBuilder: enumerated url outside source canonical prefix; skipping. url=\(urlPath) canonicalSource=\(canonicalSourcePrefix)",
+                        category: .fileSystem
+                    )
+                    skippedNonRegular += 1
+                    continue
+                }
                 let size = resourceValues.fileSize ?? 0
 
                 filesToProcess.append((url: url, relativePath: relativePath, size: Int64(size)))

--- a/ImageIntact/Models/ManifestBuilder.swift
+++ b/ImageIntact/Models/ManifestBuilder.swift
@@ -83,14 +83,32 @@ actor ManifestBuilder {
     /// On `realpath` failure (e.g. the path doesn't exist), falls back to
     /// `url.path`. Callers should be prepared for the prefix-strip to fail
     /// for URLs outside the canonical source tree.
+    ///
+    /// Passes `nil` as the second arg so `realpath` allocates the output
+    /// buffer dynamically — using a fixed `PATH_MAX` buffer would fail for
+    /// paths longer than 1024 bytes on Apple platforms (POSIX recommendation).
     static func canonicalPath(of url: URL) -> String {
-        var buf = [CChar](repeating: 0, count: Int(PATH_MAX))
         return url.withUnsafeFileSystemRepresentation { ptr -> String in
-            guard let ptr = ptr, realpath(ptr, &buf) != nil else {
+            guard let ptr = ptr, let resolved = realpath(ptr, nil) else {
                 return url.path
             }
-            return String(cString: buf)
+            defer { free(resolved) }
+            return String(cString: resolved)
         }
+    }
+
+    /// Strip `canonicalSourcePrefix` from `urlPath`. Returns `nil` when
+    /// `urlPath` doesn't start with the prefix — callers should treat that
+    /// as "url lives outside the source tree" and skip the entry rather than
+    /// storing an absolute path as the manifest's "relative" field.
+    ///
+    /// Caller is responsible for shape: the prefix should end with `/` for
+    /// non-root sources and be just `/` for the root case (so that paths
+    /// like `/Applications/Foo.app` strip correctly under a root source
+    /// without producing a leading `/`).
+    static func stripCanonicalPrefix(_ canonicalSourcePrefix: String, from urlPath: String) -> String? {
+        guard urlPath.hasPrefix(canonicalSourcePrefix) else { return nil }
+        return String(urlPath.dropFirst(canonicalSourcePrefix.count))
     }
 
     // MARK: - Helper Methods
@@ -207,6 +225,7 @@ actor ManifestBuilder {
         var skippedCache = 0
         var skippedUnsupported = 0
         var skippedByFilter = 0
+        var skippedOutsideSource = 0
 
         // macOS symlinks `/var` → `/private/var` (and `/tmp` → `/private/tmp`).
         // `FileManager.default.temporaryDirectory` hands back the `/var/...` form,
@@ -216,7 +235,12 @@ actor ManifestBuilder {
         // it follows symlinks AND returns the canonical absolute path that
         // matches the enumerator's children. Compute it once outside the loop
         // to avoid per-file filesystem I/O.
-        let canonicalSourcePrefix = Self.canonicalPath(of: source) + "/"
+        //
+        // Root source (`/`) is special-cased so the prefix is `/` rather than
+        // `//` — otherwise children like `/Applications/...` would fail the
+        // hasPrefix check.
+        let canonicalSource = Self.canonicalPath(of: source)
+        let canonicalSourcePrefix = canonicalSource == "/" ? "/" : canonicalSource + "/"
 
         // Collect files first
         while let url = enumerator.nextObject() as? URL {
@@ -283,25 +307,18 @@ actor ManifestBuilder {
                 }
 
                 // Strip the canonical source prefix to get the relativePath.
-                // `replacingOccurrences` would replace ALL substring matches —
-                // a problem if any segment of the absolute path happens to
-                // repeat the source path (e.g. `/tmp/foo/tmp/foo/x.jpg` under
-                // source `/tmp/foo`). `hasPrefix` + `dropFirst(count)` strips
-                // only the prefix. If the url doesn't start with the canonical
-                // source (e.g. the enumerator yielded a path outside the source
-                // tree via a followed symlink), skip and log — storing an
-                // absolute path as a "relative" manifest entry would silently
-                // duplicate or break the destination layout.
+                // If the url doesn't start with the canonical source (e.g. the
+                // enumerator yielded a path outside the source tree via a
+                // followed symlink), skip and log — storing an absolute path
+                // as a "relative" manifest entry would silently duplicate or
+                // break the destination layout.
                 let urlPath = url.path
-                let relativePath: String
-                if urlPath.hasPrefix(canonicalSourcePrefix) {
-                    relativePath = String(urlPath.dropFirst(canonicalSourcePrefix.count))
-                } else {
+                guard let relativePath = Self.stripCanonicalPrefix(canonicalSourcePrefix, from: urlPath) else {
                     ApplicationLogger.shared.warning(
                         "ManifestBuilder: enumerated url outside source canonical prefix; skipping. url=\(urlPath) canonicalSource=\(canonicalSourcePrefix)",
                         category: .fileSystem
                     )
-                    skippedNonRegular += 1
+                    skippedOutsideSource += 1
                     continue
                 }
                 let size = resourceValues.fileSize ?? 0
@@ -323,6 +340,7 @@ actor ManifestBuilder {
         ApplicationLogger.shared.debug("Skipped (cache): \(skippedCache)", category: .fileSystem)
         ApplicationLogger.shared.debug("Skipped (unsupported): \(skippedUnsupported)", category: .fileSystem)
         ApplicationLogger.shared.debug("Skipped (filter): \(skippedByFilter)", category: .fileSystem)
+        ApplicationLogger.shared.debug("Skipped (outside source): \(skippedOutsideSource)", category: .fileSystem)
         ApplicationLogger.shared.debug("Ready to process: \(filesToProcess.count)", category: .fileSystem)
 
         // Phase 2: Calculate checksums in batches

--- a/ImageIntact/Models/ManifestBuilder.swift
+++ b/ImageIntact/Models/ManifestBuilder.swift
@@ -186,6 +186,20 @@ actor ManifestBuilder {
         var skippedUnsupported = 0
         var skippedByFilter = 0
 
+        // macOS symlinks `/var` → `/private/var` (and `/tmp` → `/private/tmp`).
+        // FileManager.default.temporaryDirectory hands back the `/var/...` form,
+        // but `enumerator.nextObject()` returns each child with the resolved
+        // `/private/var/...` form. A plain string-strip of
+        // `source.path + "/"` against `url.path` then matches the suffix after
+        // `/private`, producing garbled relativePaths like `/privatefile.jpg`.
+        // `URL.resolvingSymlinksInPath()` does the reverse — it strips `/private`
+        // out — so resolving BOTH source AND each enumerated url puts them in
+        // the same `/var/...` form and the prefix-strip works. Production
+        // user-picked URLs typically don't traverse symlinks, so this is a
+        // no-op there; the fix is for test correctness (temp dirs) and any
+        // production path that happens to traverse `/tmp` or `/var`.
+        let resolvedSourcePrefix = source.resolvingSymlinksInPath().path + "/"
+
         // Collect files first
         while let url = enumerator.nextObject() as? URL {
             guard !shouldCancel() else { return nil }
@@ -250,7 +264,8 @@ actor ManifestBuilder {
                     ApplicationLogger.shared.debug("Found video: \(url.lastPathComponent)", category: .fileSystem)
                 }
 
-                let relativePath = url.path.replacingOccurrences(of: source.path + "/", with: "")
+                let relativePath = url.resolvingSymlinksInPath().path
+                    .replacingOccurrences(of: resolvedSourcePrefix, with: "")
                 let size = resourceValues.fileSize ?? 0
 
                 filesToProcess.append((url: url, relativePath: relativePath, size: Int64(size)))

--- a/ImageIntactTests/ManifestBuilderRelativePathTests.swift
+++ b/ImageIntactTests/ManifestBuilderRelativePathTests.swift
@@ -184,4 +184,46 @@ final class ManifestBuilderRelativePathTests: XCTestCase {
             ""
         )
     }
+
+    // MARK: - build end-to-end: symlinked subdirectory pointing outside source
+
+    /// Integration test for the safety branch in `build()`: when a symbolic
+    /// link inside the source points at content outside the source tree,
+    /// the manifest must NOT include the linked target file. With the
+    /// `FileManager` enumerator's default options (no `.followsSymlinks`),
+    /// the symlink is itself yielded as a symbolic-link entry and skipped
+    /// via the existing `isSymbolicLink` guard — verifying this behavior
+    /// end-to-end protects against future regressions if someone adds
+    /// `.followsSymlinks` to the enumerator options.
+    func testBuild_symlinkInsideSource_pointingOutsideTree_isSkipped() async throws {
+        let source = tempDir.appendingPathComponent("source")
+        let external = tempDir.appendingPathComponent("external")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+
+        // Real file inside the source — should be in the manifest.
+        try Data([0xFF]).write(to: source.appendingPathComponent("inside.jpg"))
+        // Real file outside the source — should NOT appear in the manifest.
+        try Data([0xFF]).write(to: external.appendingPathComponent("outside.jpg"))
+
+        // Symlink inside source pointing to the external dir.
+        let link = source.appendingPathComponent("escape_link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: external)
+
+        let manifest = await ManifestBuilder().build(
+            source: source,
+            shouldCancel: { false },
+            filter: FileTypeFilter(),
+            includeSubdirectories: true
+        )
+
+        XCTAssertNotNil(manifest)
+        let paths = manifest?.map { $0.relativePath } ?? []
+        XCTAssertEqual(paths, ["inside.jpg"],
+                       "Manifest must contain only the in-tree file; the symlinked external content must be skipped")
+        XCTAssertFalse(paths.contains("outside.jpg"),
+                       "outside.jpg must not appear in the manifest under any normalization of the link target")
+        XCTAssertFalse(paths.contains(where: { $0.contains("external") }),
+                       "No manifest entry may reference the external/ tree")
+    }
 }

--- a/ImageIntactTests/ManifestBuilderRelativePathTests.swift
+++ b/ImageIntactTests/ManifestBuilderRelativePathTests.swift
@@ -1,0 +1,127 @@
+//
+//  ManifestBuilderRelativePathTests.swift
+//  ImageIntactTests
+//
+//  Regression tests for the relativePath computation in ManifestBuilder.build
+//  (AMUX-228). Targets the corner cases the panel reviewer flagged:
+//   - source path name repeats inside the tree (prefix-strip must not
+//     mis-strip multiple occurrences)
+//   - enumerator yields urls outside the canonical source tree (must skip
+//     rather than store an absolute path as the manifest's "relative" field)
+//   - the canonicalPath helper itself behaves correctly for both symlinked
+//     temp paths and non-existent paths
+//
+
+import XCTest
+@testable import ImageIntact
+
+final class ManifestBuilderRelativePathTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ManifestPathTests_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if FileManager.default.fileExists(atPath: tempDir.path) {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        try await super.tearDown()
+    }
+
+    // MARK: - canonicalPath
+
+    /// The canonical form of a `/var/folders/...` URL matches the
+    /// `/private/var/folders/...` form that the directory enumerator yields
+    /// for child URLs — that's exactly the alignment we need to make
+    /// `hasPrefix` work.
+    func testCanonicalPath_resolvesPrivateVarSymlink() throws {
+        let resolved = ManifestBuilder.canonicalPath(of: tempDir)
+        let original = tempDir.path
+
+        XCTAssertTrue(
+            resolved.hasSuffix(original.dropFirst(0)) ||
+            resolved == original ||
+            resolved.contains(original.replacingOccurrences(of: "/var/", with: "/private/var/")),
+            "canonicalPath must produce a path whose enumerator children share its prefix; got '\(resolved)' for source '\(original)'"
+        )
+
+        // The stronger property: a file written to tempDir's enumerator
+        // yields a url.path that hasPrefix the canonical path.
+        let fileURL = tempDir.appendingPathComponent("probe.jpg")
+        try Data([0xFF]).write(to: fileURL)
+
+        let enumerator = FileManager.default.enumerator(at: tempDir, includingPropertiesForKeys: nil)!
+        var found = false
+        while let url = enumerator.nextObject() as? URL {
+            XCTAssertTrue(
+                url.path.hasPrefix(resolved + "/"),
+                "enumerated url '\(url.path)' must have canonical source '\(resolved)/' as a prefix"
+            )
+            found = true
+        }
+        XCTAssertTrue(found, "enumerator must yield at least one child for the test to be meaningful")
+    }
+
+    /// `realpath(3)` returns NULL when the path doesn't exist; canonicalPath
+    /// must fall back to `url.path` instead of crashing or returning an
+    /// empty string.
+    func testCanonicalPath_nonExistentPath_fallsBackToUrlPath() {
+        let bogus = URL(fileURLWithPath: "/no/such/path/exists/\(UUID().uuidString)")
+        let resolved = ManifestBuilder.canonicalPath(of: bogus)
+        XCTAssertEqual(resolved, bogus.path,
+                       "canonicalPath must fall back to url.path on realpath failure")
+    }
+
+    // MARK: - build relativePath correctness
+
+    /// Build returns relativePaths with the source prefix stripped, even
+    /// when the source name happens to repeat as a subdirectory.
+    /// Regression test for the panel reviewer's High finding: a naive
+    /// `replacingOccurrences` would strip ALL occurrences and produce a
+    /// mangled relativePath when the source name appears as a child segment.
+    func testBuild_relativePathHandlesRepeatedDirectoryNames() async throws {
+        // Create source `<tempDir>/repeat` and a subdir of the same name
+        // inside: `<tempDir>/repeat/repeat/file.jpg`. Under the old
+        // `replacingOccurrences` approach, stripping `<tempDir>/repeat/`
+        // from `<tempDir>/repeat/repeat/file.jpg` would yield `file.jpg`
+        // instead of the correct `repeat/file.jpg`.
+        let source = tempDir.appendingPathComponent("repeat")
+        let nested = source.appendingPathComponent("repeat")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try Data([0xFF]).write(to: nested.appendingPathComponent("file.jpg"))
+
+        let manifest = await ManifestBuilder().build(
+            source: source,
+            shouldCancel: { false },
+            filter: FileTypeFilter(),
+            includeSubdirectories: true
+        )
+
+        XCTAssertNotNil(manifest)
+        XCTAssertEqual(manifest?.count, 1, "Expected 1 file in manifest")
+        XCTAssertEqual(manifest?.first?.relativePath, "repeat/file.jpg",
+                       "relativePath must preserve the repeated directory segment")
+    }
+
+    /// Build returns the correct relativePath for files directly under the
+    /// source (no nested directories). Sanity test that the basic prefix
+    /// strip still works for the common case.
+    func testBuild_relativePathForRootLevelFile() async throws {
+        try Data([0xFF]).write(to: tempDir.appendingPathComponent("flat.jpg"))
+
+        let manifest = await ManifestBuilder().build(
+            source: tempDir,
+            shouldCancel: { false },
+            filter: FileTypeFilter(),
+            includeSubdirectories: true
+        )
+
+        XCTAssertEqual(manifest?.first?.relativePath, "flat.jpg",
+                       "relativePath for a root-level file is just the filename")
+    }
+}

--- a/ImageIntactTests/ManifestBuilderRelativePathTests.swift
+++ b/ImageIntactTests/ManifestBuilderRelativePathTests.swift
@@ -124,4 +124,64 @@ final class ManifestBuilderRelativePathTests: XCTestCase {
         XCTAssertEqual(manifest?.first?.relativePath, "flat.jpg",
                        "relativePath for a root-level file is just the filename")
     }
+
+    // MARK: - stripCanonicalPrefix
+
+    /// Sanity test: a urlPath under the prefix gets correctly stripped.
+    func testStripPrefix_validPrefix_strips() {
+        let stripped = ManifestBuilder.stripCanonicalPrefix(
+            "/Volumes/SourceDrive/",
+            from: "/Volumes/SourceDrive/photos/raw1.nef"
+        )
+        XCTAssertEqual(stripped, "photos/raw1.nef")
+    }
+
+    /// Repeated source-name segment inside the path: the prefix-only strip
+    /// preserves repeats that `replacingOccurrences` would mangle.
+    func testStripPrefix_repeatedNameInPath_preservesRepeat() {
+        let stripped = ManifestBuilder.stripCanonicalPrefix(
+            "/private/var/folders/abc/T/SourceRoot/",
+            from: "/private/var/folders/abc/T/SourceRoot/SourceRoot/file.jpg"
+        )
+        XCTAssertEqual(stripped, "SourceRoot/file.jpg",
+                       "Repeated source-name as a child directory must NOT be stripped twice")
+    }
+
+    /// Root-source case: prefix is `/` (not `//`), and a normal absolute
+    /// child path strips its leading `/` correctly.
+    /// Regression test for the root-directory bug flagged in round 2 review.
+    func testStripPrefix_rootSourcePrefix_stripsOnlyLeadingSlash() {
+        XCTAssertEqual(
+            ManifestBuilder.stripCanonicalPrefix("/", from: "/Applications/Foo.app"),
+            "Applications/Foo.app",
+            "Root prefix `/` must strip only the leading slash, not match `//`"
+        )
+    }
+
+    /// URL outside the source tree: stripCanonicalPrefix returns nil so the
+    /// caller can skip rather than store an absolute path as a "relative"
+    /// manifest entry. Direct unit test for the safety branch in build().
+    func testStripPrefix_pathOutsideSourceTree_returnsNil() {
+        XCTAssertNil(
+            ManifestBuilder.stripCanonicalPrefix(
+                "/Volumes/SourceDrive/",
+                from: "/Volumes/OtherDrive/photos/raw1.nef"
+            ),
+            "Paths that don't start with the source prefix must return nil so build() can skip them"
+        )
+    }
+
+    /// Edge case: empty prefix would match every string. The contract is
+    /// "must end with `/` or be just `/`" — exercise both legitimate forms
+    /// to lock in the expected behavior.
+    func testStripPrefix_exactMatch_returnsEmptyString() {
+        // A url that matches the prefix exactly (no child path) yields an
+        // empty relativePath. This shouldn't happen in normal enumeration
+        // (the source itself isn't yielded as a child) but the function's
+        // behavior should be predictable.
+        XCTAssertEqual(
+            ManifestBuilder.stripCanonicalPrefix("/foo/bar/", from: "/foo/bar/"),
+            ""
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes 10 deterministic test failures on main: 7 in `ManifestBuilderFilterTests` and 3 in `SubdirectoryTraversalTests`. Root cause is a symlink-resolution mismatch in `ManifestBuilder.build`.

## Root cause

macOS symlinks `/var` → `/private/var` and `/tmp` → `/private/tmp`. `FileManager.default.temporaryDirectory` hands back the `/var/...` form, but `enumerator.nextObject()` returns each child with the resolved `/private/var/...` form. The original relativePath computation:

```swift
let relativePath = url.path.replacingOccurrences(of: source.path + "/", with: "")
```

stripped the suffix substring starting after `/private`, producing garbled relativePaths like `/privatefile.jpg` instead of `file.jpg`. All 10 failing tests assert on specific filenames in the manifest — the assertions fail because the relativePaths are mangled.

## Fix

Resolve **both** the source URL and each enumerated url via `URL.resolvingSymlinksInPath()` before the string-strip. The method reverse-resolves `/private/var/...` back to `/var/...`, putting both in the same form so the prefix strip works correctly.

## Side effects

- **Production**: user-picked URLs (via `NSOpenPanel`) typically don't traverse symlinks. The fix is a no-op for those.
- **Any production source that does traverse `/tmp` or `/var`** was silently broken in the same way before this fix — this PR fixes that latent bug too.

## Test plan

- [x] **Targeted re-run**: `ManifestBuilderFilterTests` + `SubdirectoryTraversalTests` → 20/20 pass (was 10/20).
- [x] **Full suite**: 527/527 pass (was 502/513 with 10 deterministic fails + 1 flake on main). Zero regressions; the `testProgressTracking` flake also happened to pass cleanly this run.
- [ ] **Panel review**: running `~/.claude/tools/review pr` next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)