### PR TITLE
test: raise testProgressTracking expectation timeout 15s → 45s (AMUX-229)

### DIFF
--- a/ImageIntactTests/QueueSystem/BackupCoordinatorTests.swift
+++ b/ImageIntactTests/QueueSystem/BackupCoordinatorTests.swift
@@ -181,8 +181,12 @@ final class BackupCoordinatorTests: XCTestCase {
             )
         }
         
-        // Wait for some progress (retry backoff delays mean this can take longer)
-        await fulfillment(of: [expectation], timeout: 15.0)
+        // Wait for some progress. Under parallel test execution, contention
+        // with other suites can push the first-non-zero emission past the
+        // original 15s deadline (flake observed during AMUX-205 baseline and
+        // AMUX-228 full-suite runs). 45s gives ~3x headroom over the typical
+        // case while still failing fast on a genuinely stuck coordinator.
+        await fulfillment(of: [expectation], timeout: 45.0)
         
         // Then
         XCTAssertFalse(progressUpdates.isEmpty, "Should have progress updates")

--- a/ImageIntactTests/QueueSystem/BackupCoordinatorTests.swift
+++ b/ImageIntactTests/QueueSystem/BackupCoordinatorTests.swift
@@ -184,8 +184,12 @@ final class BackupCoordinatorTests: XCTestCase {
         // Wait for some progress. Under parallel test execution, contention
         // with other suites can push the first-non-zero emission past the
         // original 15s deadline (flake observed during AMUX-205 baseline and
-        // AMUX-228 full-suite runs). 45s gives ~3x headroom over the typical
-        // case while still failing fast on a genuinely stuck coordinator.
+        // AMUX-228 full-suite runs; observed pass timings span 11.9–14.1s
+        // under contention). 45s gives ~3x headroom over the worst-observed
+        // case while still bounding the wait — a stuck coordinator will
+        // surface within a single test's worst-case runtime rather than
+        // hanging the suite. A cleaner future fix would inject a mock timer
+        // or expose progress as an `AsyncStream` to wait on deterministically.
         await fulfillment(of: [expectation], timeout: 45.0)
         
         // Then


### PR DESCRIPTION
## Summary

Fixes the intermittent `BackupCoordinatorTests.testProgressTracking` flake by raising the `XCTestExpectation` deadline from 15s to 45s.

## Root cause

Under full-suite parallel execution, the time-to-first-non-zero `overallProgress` emission contends with all other tests for CPU and the original 15s deadline was occasionally insufficient. The flake reproduced during AMUX-205 baseline + AMUX-228 full-suite runs (failure at 15.058s). The test's existing comment already acknowledged this: "retry backoff delays mean this can take longer."

## Fix

One-line change to the timeout. Empirically, observed pass timings span 11.9–14.1s under contention, so 45s gives ~3x headroom while still failing fast on a genuinely stuck coordinator. No semantic change to what the test verifies.

## Verification

5 consecutive full-suite runs:

| Run | testProgressTracking | Suite |
|-----|---------------------|-------|
| 1 | passed (12.884s) | 537/537 |
| 2 | passed (14.058s) | 536/536 |
| 3 | passed (12.860s) | 537/537 |
| 4 | passed (13.268s) | 537/537 |
| 5 | passed (11.876s) | 536/537* |

* Run 5 had an unrelated flake in `RetryCountTests.testIsCompleteNotPrematureWithRetries` — filing as a separate incidental.

The 14.058s timing in Run 2 would have been at the very edge of the old 15s deadline and likely flaked on a slightly slower iteration.

## Test plan

- [x] **5x acceptance loop** — `testProgressTracking` passes 5/5 (ticket's acceptance criterion)
- [ ] **Panel review** — running `~/.claude/tools/review pr` next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)