### PR TITLE
fix: fresh ProgressTracker per backup session (AMUX-206)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -59,8 +59,12 @@ class BackupManager {
     var destinationItems: [DestinationItem] { destinationManager.destinationItems }
     var destinationDriveInfo: [UUID: DriveAnalyzer.DriveInfo] { destinationManager.destinationDriveInfo }
 
-    // Progress tracking delegated to ProgressTracker
-    let progressTracker = ProgressTracker()
+    // Progress tracking delegated to ProgressTracker.
+    // AMUX-206: `var` (not `let`) so runBackup can swap in a fresh instance per
+    // session. A cancelled run's orchestrator may still be spinning down and
+    // writing late; pointing the new run at a fresh tracker routes those writes
+    // to an orphaned instance instead of corrupting the new run's state.
+    var progressTracker = ProgressTracker()
 
     // Statistics tracking for completion report
     let statistics = BackupStatistics()
@@ -363,7 +367,11 @@ class BackupManager {
         state.statusMessage = "Preparing backup..."
         state.failedFiles = []
         statistics.reset()
-        progressTracker.resetAll()
+        // AMUX-206: assign a FRESH tracker rather than resetAll() the shared one,
+        // so a cancelled run's still-spinning-down orchestrator writes to an
+        // orphaned instance and never this new run's state. A fresh instance is
+        // already in reset state, so this subsumes the prior resetAll() call.
+        progressTracker = ProgressTracker()
         state.logEntries = []
         state.sessionID = UUID().uuidString
         state.shouldCancel = false

--- a/ImageIntactTests/BackupManagerReentryTests.swift
+++ b/ImageIntactTests/BackupManagerReentryTests.swift
@@ -1,0 +1,150 @@
+//
+//  BackupManagerReentryTests.swift
+//  ImageIntactTests
+//
+//  AMUX-206: cancel-then-restart re-entrancy fix.
+//
+//  `cancelOperation` flips `state.isProcessing = false` synchronously while the
+//  old orchestrator is still spinning down. A user can immediately start a
+//  second backup; both runs share the same `progressTracker`, so the dying
+//  orchestrator's late writes corrupt the new run's state. The fix makes
+//  `runBackup` assign a FRESH ProgressTracker per session, so late writes from
+//  the prior orchestrator land on an orphaned instance.
+//
+//  Red phase (pre-fix: `let progressTracker`): runBackup cannot reassign the
+//  tracker, so (a) the instance is unchanged across runs and (b) a late write
+//  into the prior instance leaks into the new run. Both fail.
+//  Test (c) is a UX regression guard: it passes before AND after the fix,
+//  protecting the synchronous `state.isProcessing = false` flip.
+//
+
+import XCTest
+import Observation
+@testable import ImageIntact
+
+@MainActor
+final class BackupManagerReentryTests: BaseBackupManagerTestCase {
+
+    private var mockFileOps: MockFileOperations!
+    private var mockDiskSpace: MockDiskSpaceChecker!
+    private var mockPresenter: MockBackupAlertPresenter!
+    private var prefs: InMemoryPreferencesProvider!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        mockFileOps = MockFileOperations()
+        mockDiskSpace = MockDiskSpaceChecker()
+        mockPresenter = MockBackupAlertPresenter()
+        prefs = InMemoryPreferencesProvider()
+
+        // Disk-space check passes with no warnings, and the preflight modal is
+        // skipped, so runBackup clears every guard and reaches its state-setup
+        // block — where the fresh-tracker assignment lives.
+        mockDiskSpace.evaluationResult = (canProceed: true, warnings: [], errors: [])
+        prefs.showPreflightSummary = false
+
+        bm = BackupManager(
+            fileOperations: mockFileOps,
+            diskSpaceChecker: mockDiskSpace,
+            backupAlertPresenter: mockPresenter,
+            preferences: prefs
+        )
+    }
+
+    override func tearDown() async throws {
+        prefs = nil
+        mockPresenter = nil
+        mockDiskSpace = nil
+        mockFileOps = nil
+        // Base tearDown cancels any in-flight backup before releasing bm.
+        try await super.tearDown()
+    }
+
+    /// Source + one destination so runBackup clears every guard and reaches the
+    /// state-setup block (the fresh-tracker assignment site). Fake file URLs
+    /// have no security scope, so the dispatched `performQueueBasedBackup` bails
+    /// at its `startAccessingSecurityScopedResource` guard — no real backup work
+    /// runs, keeping these tests deterministic.
+    private func setUpSourceAndDestination() {
+        bm.setSource(URL(fileURLWithPath: "/Volumes/CardA/DCIM"))
+        bm.setDestination(URL(fileURLWithPath: "/Volumes/BackupDrive"), at: 0)
+    }
+
+    /// (a) runBackup assigns a fresh ProgressTracker; cancelOperation must NOT
+    ///     swap it; a restart after cancel assigns another fresh instance.
+    func testRunBackupAssignsFreshTracker_andCancelDoesNotSwap() {
+        setUpSourceAndDestination()
+
+        let original = bm.progressTracker
+        bm.runBackup()
+        let firstRun = bm.progressTracker
+        XCTAssertFalse(original === firstRun,
+                       "runBackup must assign a fresh ProgressTracker, not reuse the prior instance")
+
+        bm.cancelOperation()
+        XCTAssertTrue(firstRun === bm.progressTracker,
+                      "cancelOperation must NOT swap the tracker (it preserves the cancelled badges)")
+
+        bm.runBackup()
+        XCTAssertFalse(firstRun === bm.progressTracker,
+                       "a restart after cancel must assign another fresh ProgressTracker")
+    }
+
+    /// (b) Bug repro: a dying orchestrator's late write into the prior tracker
+    ///     instance must NOT appear on the new run's tracker.
+    func testDyingOrchestratorLateWriteDoesNotLeakIntoNewRun() {
+        setUpSourceAndDestination()
+
+        bm.runBackup()
+        let firstRunTracker = bm.progressTracker   // the instance the first orchestrator captured
+        bm.cancelOperation()
+        bm.runBackup()                             // fixed: fresh instance; buggy: same instance
+
+        // Simulate the still-spinning-down first orchestrator writing late.
+        firstRunTracker.totalFiles = 9999
+
+        XCTAssertEqual(bm.progressTracker.totalFiles, 0,
+                       "the new run's tracker must be isolated from the dying orchestrator's late write")
+        XCTAssertFalse(firstRunTracker === bm.progressTracker,
+                       "the new run must not share the prior run's tracker instance")
+    }
+
+    /// (c) UX regression guard: state.isProcessing flips to false synchronously
+    ///     inside cancelOperation — the instant 'Backup cancelled' behavior the
+    ///     correctness reviewer praised. Passes before and after the fix.
+    func testCancelFlipsIsProcessingSynchronously() {
+        setUpSourceAndDestination()
+
+        bm.runBackup()
+        XCTAssertTrue(bm.state.isProcessing, "runBackup sets isProcessing synchronously")
+
+        bm.cancelOperation()
+        XCTAssertFalse(bm.state.isProcessing,
+                       "cancelOperation must clear isProcessing synchronously (no await)")
+    }
+
+    /// (d) Observation payoff: a reader of `bm.progressTracker.X` is notified
+    ///     when the tracker instance is reassigned. SwiftUI's @Observable view
+    ///     updates are built on `withObservationTracking`, so this deterministic
+    ///     unit-level check proves the user-facing re-render/rebind that the
+    ///     fix depends on (ticket step 6) without driving the GUI: a progress
+    ///     view reading `bm.progressTracker.totalFiles` re-renders and rebinds
+    ///     to the fresh instance when runBackup swaps it.
+    func testReassigningTrackerNotifiesObserverReadingThroughBM() {
+        var notified = false
+        withObservationTracking {
+            // Exactly how a progress view reads progress: through bm into the tracker.
+            _ = bm.progressTracker.totalFiles
+        } onChange: {
+            notified = true
+        }
+
+        // Reassign the instance only (no field mutation). An observer that read
+        // bm.progressTracker.X must be invalidated — i.e. the view re-renders.
+        bm.progressTracker = ProgressTracker()
+
+        XCTAssertTrue(notified,
+                      "reassigning bm.progressTracker must notify observers reading bm.progressTracker.X (the SwiftUI re-render/rebind trigger)")
+    }
+}


### PR DESCRIPTION
## Problem (PR #119 R2, architecture review HIGH)

`cancelOperation` flips `isProcessing = false` synchronously while the old
orchestrator is still spinning down, so a user can immediately restart a
backup. Both runs shared a single `progressTracker` instance, so the dying
orchestrator's late writes (it observes the cancel flag asynchronously)
corrupt the new run's progress state — the new run's UI can show residual
counts/bytes from the cancelled run.

## Fix (path A)

Make `progressTracker` a `var` and assign a **fresh** `ProgressTracker()` at
the top of `runBackup`'s state-setup block instead of `resetAll()`-ing the
shared one. The new run's orchestrator captures the fresh tracker; the dying
orchestrator's writes land on an orphaned instance (harmless GC fodder).

- Preserves the synchronous `isProcessing = false` flip — the instant
  "Backup cancelled" UX the correctness reviewer praised. No cancelling-state
  machine (path B, rejected 2026-05-23).
- A fresh instance is already in reset state, so it subsumes the prior
  `resetAll()` call (state-equivalent + swaps the instance).
- `BackupManager` and `ProgressTracker` are both `@Observable`; views read
  through `bm` (`bm.progressTracker.X` or the `bm.X` forwards), so
  reassignment re-renders and rebinds with **no view changes** (audited).

## Tests

`ImageIntactTests/BackupManagerReentryTests.swift`:
- instance swaps on `runBackup`; no swap on `cancelOperation`; restart-after-cancel swaps again
- a dying orchestrator's late write into the prior tracker does **not** leak into the new run
- `isProcessing` flips false synchronously in `cancelOperation` (UX regression guard)

TDD: red (2 fail / 1 pass) → green. Full suite **540/540** (`platform=macOS`).
The first full-suite run hit the unrelated, pre-existing `RetryCountTests`
flake (AMUX-232); the rerun was clean 540/540, confirming it transient and
outside this change's code path.

## Note

Sibling tickets AMUX-201 (BackupState extraction) and AMUX-202 (drop
progressTracker forwards) are in flight concurrently and also touch
`BackupManager.swift`; they were scoped to leave the `progressTracker`
declaration line to this ticket. Whichever merges first, the others rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)