### PR TITLE
test: make MockFileOperations thread-safe (AMUX-232)

### DIFF
--- a/ImageIntactTests/MockFileOperationsThreadSafetyTests.swift
+++ b/ImageIntactTests/MockFileOperationsThreadSafetyTests.swift
@@ -1,0 +1,54 @@
+//
+//  MockFileOperationsThreadSafetyTests.swift
+//  ImageIntactTests
+//
+//  AMUX-232: deflake RetryCountTests.testIsCompleteNotPrematureWithRetries.
+//
+//  Root cause (captured crash report ImageIntact-2026-05-29-103654.ips):
+//  DestinationQueue spawns multiple workers whose `await fileOperations.X` calls
+//  run on the generic executor (the mock's methods are nonisolated), so two
+//  workers mutate MockFileOperations' shared `filesExist: Set<URL>` (and its
+//  tracking arrays/dicts) in parallel. Concurrent Set mutation corrupts its
+//  storage; a later `Set.contains` dispatches into freed memory and aborts with
+//  EXC_CRASH (SIGABRT, doesNotRecognizeSelector) — observed as a 0.000s
+//  "failure" of testIsCompleteNotPrematureWithRetries under full-suite parallel
+//  execution (~1/5).
+//
+//  This test reproduces that race deterministically by hammering the mock's
+//  synchronous filesExist-touching methods from many threads via
+//  concurrentPerform (guaranteed real parallelism). Against the unsynchronized
+//  mock it corrupts/aborts the test process (red); once the mock guards its
+//  state with a lock it runs clean (green).
+//
+
+@testable import ImageIntact
+import XCTest
+
+final class MockFileOperationsThreadSafetyTests: XCTestCase {
+
+    /// Concurrent insert/contains/remove on the mock's shared `filesExist` Set
+    /// (the exact pattern DestinationQueue's parallel workers produce) must not
+    /// corrupt its backing storage or crash.
+    func testConcurrentFilesExistAccessIsThreadSafe() {
+        let mock = MockFileOperations()
+
+        // 8 threads × 2000 iterations of interleaved insert/contains/remove on
+        // the shared Set. On an unsynchronized Set this reliably corrupts the
+        // internal storage and aborts the process.
+        DispatchQueue.concurrentPerform(iterations: 8) { thread in
+            for i in 0..<2000 {
+                let url = URL(fileURLWithPath: "/race/\(thread)/\(i).dat")
+                _ = mock.fileExists(at: url)
+                try? mock.createDirectory(at: url, withIntermediateDirectories: false)
+                _ = mock.fileExists(at: url)
+                _ = mock.createFile(at: url, contents: nil, attributes: nil)
+                try? mock.removeItem(at: url)
+            }
+        }
+
+        // Reaching here without aborting means the mock survived concurrent
+        // access. (State is intentionally not asserted — the inserts and removes
+        // race by design; the contract under test is "no corruption/crash".)
+        XCTAssertTrue(true, "MockFileOperations survived concurrent filesExist access")
+    }
+}

--- a/ImageIntactTests/Mocks/MockFileOperations.swift
+++ b/ImageIntactTests/Mocks/MockFileOperations.swift
@@ -8,9 +8,30 @@
 import Foundation
 @testable import ImageIntact
 
-/// Mock implementation of FileOperationsProtocol for testing
+/// Mock implementation of FileOperationsProtocol for testing.
+///
+/// AMUX-232: This mock is exercised concurrently. `DestinationQueue` runs
+/// multiple workers, and because the protocol methods are nonisolated, a worker's
+/// `await fileOperations.X` runs on the generic executor (off the queue actor) —
+/// so two workers mutate this mock's shared state in parallel. Swift collections
+/// are not thread-safe; concurrent mutation corrupts their storage and aborts the
+/// process (observed crash: `Set.contains` → `doesNotRecognizeSelector` → SIGABRT
+/// in `fileExists`). All access to the mutable tracking/configuration state below
+/// therefore goes through `stateLock`.
 class MockFileOperations: FileOperationsProtocol {
-    
+
+    /// Serializes every access to this mock's mutable state. Recursive so a
+    /// subclass override (e.g. SelectiveFailMockFileOperations) can hold it and
+    /// still call `super`, and so any future intra-method delegation is safe.
+    private let stateLock = NSRecursiveLock()
+
+    @discardableResult
+    private func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return try body()
+    }
+
     // MARK: - Tracking properties for assertions
     var copiedFiles: [(source: URL, destination: URL)] = []
     var createdDirectories: [URL] = []
@@ -41,155 +62,179 @@ class MockFileOperations: FileOperationsProtocol {
         case itemRemovalFailed
         case trashFailed
     }
-    
+
     // MARK: - FileOperationsProtocol implementation
-    
+
     func copyItem(at source: URL, to destination: URL) async throws {
-        copiedFiles.append((source: source, destination: destination))
-        
-        if shouldFailCopy {
-            throw MockError.copyFailed
-        }
-        
-        // Simulate successful copy by adding destination to exists set
-        filesExist.insert(destination)
-        
-        // Copy over mock attributes if they exist
-        if let sourceSize = mockFileSizes[source] {
-            mockFileSizes[destination] = sourceSize
-        }
-        if let sourceChecksum = mockChecksums[source] {
-            mockChecksums[destination] = sourceChecksum
+        try withLock {
+            copiedFiles.append((source: source, destination: destination))
+
+            if shouldFailCopy {
+                throw MockError.copyFailed
+            }
+
+            // Simulate successful copy by adding destination to exists set
+            filesExist.insert(destination)
+
+            // Copy over mock attributes if they exist
+            if let sourceSize = mockFileSizes[source] {
+                mockFileSizes[destination] = sourceSize
+            }
+            if let sourceChecksum = mockChecksums[source] {
+                mockChecksums[destination] = sourceChecksum
+            }
         }
     }
-    
+
     func fileExists(at url: URL) -> Bool {
-        return filesExist.contains(url)
+        withLock { filesExist.contains(url) }
     }
-    
+
     func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool) throws {
-        createdDirectories.append(url)
-        filesExist.insert(url)
+        withLock {
+            createdDirectories.append(url)
+            filesExist.insert(url)
+        }
     }
-    
+
     func removeItem(at url: URL) throws {
-        removedItems.append(url)
-        filesExist.remove(url)
-        mockFileSizes.removeValue(forKey: url)
-        mockChecksums.removeValue(forKey: url)
-        mockAttributes.removeValue(forKey: url)
+        withLock {
+            removedItems.append(url)
+            filesExist.remove(url)
+            mockFileSizes.removeValue(forKey: url)
+            mockChecksums.removeValue(forKey: url)
+            mockAttributes.removeValue(forKey: url)
+        }
     }
 
     func trashItem(at url: URL) throws {
-        trashedItems.append(url)
-        if shouldFailTrash {
-            throw MockError.trashFailed
+        try withLock {
+            trashedItems.append(url)
+            if shouldFailTrash {
+                throw MockError.trashFailed
+            }
+            // Simulate the trash by removing the file from the exists set.
+            filesExist.remove(url)
+            mockFileSizes.removeValue(forKey: url)
+            mockChecksums.removeValue(forKey: url)
+            mockAttributes.removeValue(forKey: url)
         }
-        // Simulate the trash by removing the file from the exists set.
-        filesExist.remove(url)
-        mockFileSizes.removeValue(forKey: url)
-        mockChecksums.removeValue(forKey: url)
-        mockAttributes.removeValue(forKey: url)
     }
-    
+
     func attributesOfItem(at url: URL) throws -> [FileAttributeKey: Any] {
-        if let attributes = mockAttributes[url] {
+        withLock {
+            if let attributes = mockAttributes[url] {
+                return attributes
+            }
+
+            // Return default attributes
+            var attributes: [FileAttributeKey: Any] = [:]
+            attributes[.size] = mockFileSizes[url] ?? 0
+            attributes[.type] = filesExist.contains(url) ? FileAttributeType.typeRegular : nil
             return attributes
         }
-        
-        // Return default attributes
-        var attributes: [FileAttributeKey: Any] = [:]
-        attributes[.size] = mockFileSizes[url] ?? 0
-        attributes[.type] = filesExist.contains(url) ? FileAttributeType.typeRegular : nil
-        return attributes
     }
-    
+
     func calculateChecksum(for url: URL, shouldCancel: @Sendable @escaping () -> Bool) async throws -> String {
-        checksumCalculations.append(url)
-        
-        if shouldFailChecksum {
-            throw MockError.checksumFailed
+        try withLock {
+            checksumCalculations.append(url)
+
+            if shouldFailChecksum {
+                throw MockError.checksumFailed
+            }
+
+            if let checksum = mockChecksums[url] {
+                return checksum
+            }
+
+            // Return a default checksum
+            return "mock_checksum_\(url.lastPathComponent)"
         }
-        
-        if let checksum = mockChecksums[url] {
-            return checksum
-        }
-        
-        // Return a default checksum
-        return "mock_checksum_\(url.lastPathComponent)"
     }
-    
+
     func startAccessingSecurityScopedResource(for url: URL) -> Bool {
-        securityScopedAccesses.append(url)
-        return true
+        withLock {
+            securityScopedAccesses.append(url)
+            return true
+        }
     }
-    
+
     func stopAccessingSecurityScopedResource(for url: URL) {
         // Just track that this was called
     }
-    
+
     func fileSize(at url: URL) -> Int64? {
-        return mockFileSizes[url]
+        withLock { mockFileSizes[url] }
     }
 
     func moveItem(at source: URL, to destination: URL) throws {
-        if shouldFailCopy { throw MockError.copyFailed }
-        movedItems.append((source: source, destination: destination))
+        try withLock {
+            if shouldFailCopy { throw MockError.copyFailed }
+            movedItems.append((source: source, destination: destination))
+        }
     }
 
     func setAttributes(_ attributes: [FileAttributeKey: Any], at url: URL) throws {
-        setAttributesCalls.append((attributes: attributes, url: url))
+        withLock {
+            setAttributesCalls.append((attributes: attributes, url: url))
+        }
     }
 
     func contentsOfDirectory(at url: URL, includingPropertiesForKeys keys: [URLResourceKey]?) throws -> [URL] {
-        return mockDirectoryContents[url] ?? []
+        withLock { mockDirectoryContents[url] ?? [] }
     }
 
     func createFile(at url: URL, contents data: Data?, attributes: [FileAttributeKey: Any]?) -> Bool {
-        if shouldFailCreateFile { return false }
-        createdFiles.append((url: url, data: data, attributes: attributes))
-        filesExist.insert(url)
-        return true
+        withLock {
+            if shouldFailCreateFile { return false }
+            createdFiles.append((url: url, data: data, attributes: attributes))
+            filesExist.insert(url)
+            return true
+        }
     }
-    
+
     // MARK: - Test helper methods
-    
+
     /// Reset all tracking arrays and state
     func reset() {
-        copiedFiles.removeAll()
-        createdDirectories.removeAll()
-        removedItems.removeAll()
-        checksumCalculations.removeAll()
-        securityScopedAccesses.removeAll()
-        
-        shouldFailCopy = false
-        shouldFailChecksum = false
-        shouldFailCreateFile = false
-        filesExist.removeAll()
-        mockChecksums.removeAll()
-        mockFileSizes.removeAll()
-        mockAttributes.removeAll()
-        movedItems.removeAll()
-        setAttributesCalls.removeAll()
-        mockDirectoryContents.removeAll()
-        createdFiles.removeAll()
+        withLock {
+            copiedFiles.removeAll()
+            createdDirectories.removeAll()
+            removedItems.removeAll()
+            checksumCalculations.removeAll()
+            securityScopedAccesses.removeAll()
+
+            shouldFailCopy = false
+            shouldFailChecksum = false
+            shouldFailCreateFile = false
+            filesExist.removeAll()
+            mockChecksums.removeAll()
+            mockFileSizes.removeAll()
+            mockAttributes.removeAll()
+            movedItems.removeAll()
+            setAttributesCalls.removeAll()
+            mockDirectoryContents.removeAll()
+            createdFiles.removeAll()
+        }
     }
-    
+
     /// Add a mock file with specified properties
     func addMockFile(at url: URL, size: Int64, checksum: String) {
-        filesExist.insert(url)
-        mockFileSizes[url] = size
-        mockChecksums[url] = checksum
+        withLock {
+            filesExist.insert(url)
+            mockFileSizes[url] = size
+            mockChecksums[url] = checksum
+        }
     }
-    
+
     /// Verify that a file was copied from source to destination
     func verifyCopied(from source: URL, to destination: URL) -> Bool {
-        return copiedFiles.contains { $0.source == source && $0.destination == destination }
+        withLock { copiedFiles.contains { $0.source == source && $0.destination == destination } }
     }
-    
+
     /// Get count of operations
-    var copyCount: Int { copiedFiles.count }
-    var directoryCreationCount: Int { createdDirectories.count }
-    var removalCount: Int { removedItems.count }
-    var checksumCount: Int { checksumCalculations.count }
+    var copyCount: Int { withLock { copiedFiles.count } }
+    var directoryCreationCount: Int { withLock { createdDirectories.count } }
+    var removalCount: Int { withLock { removedItems.count } }
+    var checksumCount: Int { withLock { checksumCalculations.count } }
 }


### PR DESCRIPTION
## Flake

`RetryCountTests.testIsCompleteNotPrematureWithRetries` flaked ~1/5 under full-suite parallel execution — an immediate **0.000s "failure"** with no assertion message (followup of AMUX-229).

## Root cause (from the OS crash report)

The 0.000s/no-assertion signature was a **process crash**, not an assertion. The captured report (`ImageIntact-2026-05-29-103654.ips`) shows:

```
EXC_CRASH (SIGABRT) — doesNotRecognizeSelector
  Set.contains(_:)
  MockFileOperations.fileExists(at:)
  RetryHandler.copyFileWithRetry … DestinationQueue.runWorker
```

`DestinationQueue` runs multiple workers. Because the mock's `FileOperationsProtocol` methods are **nonisolated**, each worker's `await fileOperations.X` runs *off* the queue actor on the generic executor — so two workers mutate the mock's shared `filesExist: Set<URL>` (and its tracking arrays/dicts) **in parallel**. Swift collections aren't thread-safe; concurrent mutation corrupts the Set's storage, and a later `Set.contains` dispatches into freed memory → SIGABRT. Full-suite CPU contention is what makes the two workers run truly parallel, hence the order/contention dependence.

**Not a production bug** — the real `FileManager`-backed `FileOperations` is stateless/thread-safe. The mock simply didn't honor the concurrent-access contract `DestinationQueue` relies on.

## Fix

Guard every mutable-state access in `MockFileOperations` with a recursive lock. The `SelectiveFailMockFileOperations` subclass needs no change (its `super.copyItem` hits the locked base; its `failingFiles` is read-only during a run). The `async` methods have no internal `await`, so the lock is never held across suspension.

## Tests

New `MockFileOperationsThreadSafetyTests` hammers the shared Set from 8 threads via `concurrentPerform`:
- **Red:** crashes the unsynchronized mock with the *same* 0.000s/no-assertion signature as the production flake.
- **Green:** passes once the lock is in place.

This deterministic red→green is stronger than the ticket's probabilistic "10 consecutive runs" — but I ran those too: **10/10 consecutive full-suite runs green**, `testIsCompleteNotPrematureWithRetries` and the stress test passing every run (sha `e9673a0`).

## Follow-up

Subclass-level counters that bypass the base lock (e.g. `MockFileOperationsWithRetry.copyAttempts`) remain unsynchronized — latent, lower-severity; filed separately. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)