### PR TITLE
refactor: split BackupManager files below 500-line limit (AMUX-230)

### DIFF
--- a/ImageIntact/Models/BackupManager+Completion.swift
+++ b/ImageIntact/Models/BackupManager+Completion.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+// MARK: - Backup Completion
+//
+// Split out of BackupManagerQueueIntegration.swift (AMUX-230, 500-line limit).
+
+extension BackupManager {
+    /// Handle backup completion (notifications and UI).
+    /// `internal` (not `private`) so tests can drive it directly with mocked
+    /// `preferences` / `notificationService` and assert which prefs reads gate
+    /// which side effects (AMUX-205 panel review round 4).
+    @MainActor
+    func handleBackupCompletion(destinations: [URL]) async {
+        // Stop preventing sleep
+        SleepPrevention.shared.stopPreventingSleep()
+
+        // Show completion report if not cancelled
+        if !state.shouldCancel {
+            // Send notification if enabled
+            if preferences.showNotificationOnComplete {
+                notificationService.sendBackupCompletionNotification(
+                    filesCopied: progressTracker.processedFiles,
+                    destinations: destinations.count,
+                    duration: statistics.duration ?? 0
+                )
+            }
+
+            // Small delay to ensure UI is ready
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            showCompletionReport = true
+
+            // Offer to trash source if enabled and backup was fully successful
+            if preferences.trashSourceAfterBackup
+                && state.failedFiles.isEmpty
+                && sourceURL != nil
+            {
+                showTrashConfirmation = true
+            }
+        } else {
+            // Clear the overall status text when cancelled
+            state.overallStatusText = ""
+            state.statusMessage = "Backup cancelled"
+
+            // Still stop sleep prevention even if cancelled
+            logInfo("Backup cancelled by user")
+        }
+    }
+}

--- a/ImageIntact/Models/BackupManager+Forwarding.swift
+++ b/ImageIntact/Models/BackupManager+Forwarding.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+// MARK: - Forwarding Accessors
+//
+// Thin delegation layer split out of BackupManager.swift (AMUX-230, 500-line
+// limit). Pure forwarding to state / sourceManager / destinationManager /
+// progressTracker — no logic lives here.
+
+extension BackupManager {
+    // MARK: - Modal Presentation Flags
+
+    // Forwarded to state so $backupManager.showX bindings keep working.
+    var showCompletionReport: Bool { get { state.showCompletionReport } set { state.showCompletionReport = newValue } }
+    var showMigrationDialog: Bool { get { state.showMigrationDialog } set { state.showMigrationDialog = newValue } }
+    var showDuplicateWarning: Bool { get { state.showDuplicateWarning } set { state.showDuplicateWarning = newValue } }
+    var showTrashConfirmation: Bool { get { state.showTrashConfirmation } set { state.showTrashConfirmation = newValue } }
+    var showLargeBackupConfirmation: Bool { get { state.showLargeBackupConfirmation } set { state.showLargeBackupConfirmation = newValue } }
+
+    // MARK: - Destination Forwarding (read-only)
+
+    var destinationURLs: [URL?] { destinationManager.destinationURLs }
+    var destinationItems: [DestinationItem] { destinationManager.destinationItems }
+    var destinationDriveInfo: [UUID: DriveAnalyzer.DriveInfo] { destinationManager.destinationDriveInfo }
+
+    // MARK: - Source Forwarding
+
+    // Source-related properties are now on sourceManager
+    // Convenience accessors for code that still reads these directly
+    var sourceURL: URL? {
+        get { sourceManager.sourceURL }
+        set { sourceManager.sourceURL = newValue }
+    }
+    var sourceFileTypes: [ImageFileType: Int] {
+        get { sourceManager.sourceFileTypes }
+        set { sourceManager.sourceFileTypes = newValue }
+    }
+    var isScanning: Bool { sourceManager.isScanning }
+    var scanProgress: String {
+        get { sourceManager.scanProgress }
+        set { sourceManager.scanProgress = newValue }
+    }
+    var sourceTotalBytes: Int64 { sourceManager.sourceTotalBytes }
+    var fileTypeFilter: FileTypeFilter {
+        get { sourceManager.fileTypeFilter }
+        set { sourceManager.fileTypeFilter = newValue }
+    }
+    var includeSubdirectories: Bool {
+        get { sourceManager.includeSubdirectories }
+        set { sourceManager.includeSubdirectories = newValue }
+    }
+    var excludeCacheFiles: Bool {
+        get { sourceManager.excludeCacheFiles }
+        set { sourceManager.excludeCacheFiles = newValue }
+    }
+
+    // MARK: - Source Tag Delegation
+
+    func checkForSourceTag(at url: URL) -> Bool {
+        sourceManager.checkForSourceTag(at: url)
+    }
+
+    // MARK: - Progress Forwarding
+
+    func formattedETA() -> String {
+        return progressTracker.formattedETA()
+    }
+
+    @MainActor
+    func initializeDestinations(_ destinations: [URL]) async {
+        progressTracker.initializeDestinations(destinations)
+    }
+
+    @MainActor
+    func incrementDestinationProgress(_ destinationName: String) {
+        _ = progressTracker.incrementDestinationProgress(destinationName)
+    }
+
+    // MARK: - File Scanning (delegated to SourceManager)
+
+    func getFormattedFileTypeSummary(groupRaw: Bool = false) -> String {
+        sourceManager.getFormattedFileTypeSummary(groupRaw: groupRaw)
+    }
+
+    func getFilteredFilesSummary() -> (summary: String, willCopy: Int, total: Int)? {
+        sourceManager.getFilteredFilesSummary()
+    }
+
+    func getDestinationEstimate(at index: Int) -> String? {
+        destinationManager.getDestinationEstimate(at: index, sourceState: SourceEstimateState(
+            sourceURL: sourceManager.sourceURL,
+            sourceTotalBytes: sourceManager.sourceTotalBytes,
+            sourceFileTypes: sourceManager.sourceFileTypes,
+            isScanning: sourceManager.isScanning
+        ))
+    }
+}

--- a/ImageIntact/Models/BackupManager+LargeBackup.swift
+++ b/ImageIntact/Models/BackupManager+LargeBackup.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+// MARK: - Large Backup Confirmation
+//
+// Split out of BackupManagerQueueIntegration.swift (AMUX-230, 500-line limit).
+
+extension BackupManager {
+    /// Check if this is a large backup and wait for user confirmation if needed.
+    /// Returns true if backup should proceed, false if user cancelled.
+    /// `internal` (not `private`) so tests can drive the early-return branches
+    /// directly and assert which prefs reads gate which behavior (AMUX-205
+    /// panel review round 4).
+    @MainActor
+    func checkForLargeBackupAndWait(
+        source _: URL, destinations: [URL], manifest: [FileManifestEntry]
+    ) async -> Bool {
+        ApplicationLogger.shared.debug(
+            "Checking for large backup (threshold: \(preferences.largeBackupFileThreshold) files / \(preferences.largeBackupSizeThresholdGB) GB)",
+            category: .backup
+        )
+
+        // Skip if user disabled confirmations or already disabled warnings
+        guard
+            preferences.confirmLargeBackups
+            && !preferences.skipLargeBackupWarning
+        else {
+            return true // Proceed with backup
+        }
+
+        // Check for cancellation
+        guard !state.shouldCancel else { return false }
+
+        state.statusMessage = "Analyzing backup size..."
+
+        let fileThreshold = preferences.largeBackupFileThreshold
+        let sizeThresholdBytes = Int64(
+            preferences.largeBackupSizeThresholdGB * 1_000_000_000)
+        let totalBytes = manifest.reduce(0) { $0 + $1.size }
+
+        // Check if backup exceeds thresholds
+        guard manifest.count > fileThreshold || totalBytes > sizeThresholdBytes else {
+            return true // Proceed with backup
+        }
+
+        ApplicationLogger.shared.debug(
+            "Large backup detected: \(manifest.count) files, \(String(format: "%.1f", Double(totalBytes) / 1_000_000_000)) GB",
+            category: .backup
+        )
+
+        // Calculate estimated time
+        let estimatedSpeed = 50.0 // MB/s - conservative estimate
+        let seconds = Double(totalBytes) / (estimatedSpeed * 1_000_000)
+        let timeString = TimeFormatter.formatDuration(seconds)
+
+        state.largeBackupInfo = BackupState.LargeBackupInfo(
+            fileCount: manifest.count,
+            totalBytes: totalBytes,
+            destinationCount: destinations.count,
+            estimatedTimePerDestination: timeString
+        )
+        showLargeBackupConfirmation = true
+
+        // Wait for user response using CheckedContinuation
+        let result = await withCheckedContinuation { continuation in
+            state.largeBackupContinuation = continuation
+        }
+
+        return result
+    }
+
+    /// User responded to large backup confirmation
+    @MainActor
+    func respondToLargeBackupConfirmation(shouldContinue: Bool, dontShowAgain: Bool) {
+        showLargeBackupConfirmation = false
+        state.largeBackupInfo = nil
+
+        if dontShowAgain {
+            preferences.skipLargeBackupWarning = true
+        }
+
+        // Resume the waiting backup process
+        if let continuation = state.largeBackupContinuation {
+            continuation.resume(returning: shouldContinue)
+            state.largeBackupContinuation = nil
+        } else {
+            ApplicationLogger.shared.debug("No continuation to resume for large backup confirmation", category: .backup)
+        }
+    }
+}

--- a/ImageIntact/Models/BackupManager+Preflight.swift
+++ b/ImageIntact/Models/BackupManager+Preflight.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+// MARK: - Preflight Summary
+//
+// Split out of BackupManager.swift (AMUX-230, 500-line limit).
+
+extension BackupManager {
+    /// Build the data snapshot the preflight presenter needs.
+    /// Pure data construction — no UI. Pulled out so runBackup is easy to read
+    /// and the summary construction is testable in isolation.
+    /// `internal` (not `private`) only because extensions in a separate file
+    /// can't see private members; only runBackup should call this.
+    func buildPreflightSummary(source: URL, destinations: [URL]) -> PreflightSummary {
+        // Filtered summary (when a file-type filter is active).
+        let filteredSummary = getFilteredFilesSummary()
+
+        // Non-filtered file count and type summary (used when no filter is active).
+        let nonFilteredTotalFiles = sourceFileTypes.values.reduce(0, +)
+        let nonFilteredTypeSummary: String? = sourceFileTypes.isEmpty ? nil : getFormattedFileTypeSummary()
+
+        // Build destination tuples with optional drive device names.
+        // Zip the raw parallel arrays before filtering nils so indices stay aligned:
+        // compactMap on destinationURLs alone would shift the index into
+        // destinationItems if any earlier slot is nil.
+        let validPairs: [(URL, DestinationItem)] = zip(destinationURLs, destinationItems).compactMap { url, item in
+            guard let url = url else { return nil }
+            return (url, item)
+        }
+        let destTuples: [(name: String, deviceName: String?)] = validPairs.map { url, item in
+            let deviceName = destinationDriveInfo[item.id]?.deviceName
+            let resolvedDeviceName = (deviceName?.isEmpty == false) ? deviceName : nil
+            return (name: url.lastPathComponent, deviceName: resolvedDeviceName)
+        }
+
+        return PreflightSummary(
+            sourceName: source.lastPathComponent,
+            sourcePath: source.path,
+            filteredSummary: filteredSummary,
+            fileTypeSummary: nonFilteredTypeSummary,
+            totalFiles: nonFilteredTotalFiles,
+            totalBytes: sourceTotalBytes,
+            destinations: destTuples,
+            excludeCacheFiles: preferences.excludeCacheFiles,
+            skipHiddenFiles: preferences.skipHiddenFiles,
+            fileTypeFilterActive: !fileTypeFilter.includedExtensions.isEmpty
+        )
+    }
+}

--- a/ImageIntact/Models/BackupManager+UITestSupport.swift
+++ b/ImageIntact/Models/BackupManager+UITestSupport.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// MARK: - UI Test Support
+//
+// Split out of BackupManager.swift (AMUX-230, 500-line limit).
+
+extension BackupManager {
+    /// `internal` (not `private`) only because extensions in a separate file
+    /// can't see private members; treat as init-only (called from init when
+    /// launched with --uitest).
+    func loadUITestPaths() {
+        // The TestSourcePath / TestOrganizationName UserDefaults overrides are
+        // for UI testing only. Wrap in #if DEBUG so a malicious local process
+        // can't `defaults write` an arbitrary path into a Full-Disk-Access-
+        // granted release build to coerce the app into reading protected files.
+        #if DEBUG
+        logInfo("Loading UI test paths")
+
+        // Load test source path
+        if let testSourcePath = UserDefaults.standard.string(forKey: "TestSourcePath") {
+            let sourceURL = URL(fileURLWithPath: testSourcePath)
+            self.sourceManager.sourceURL = sourceURL
+            organizationName = SmartFolderName.from(url: sourceURL)
+            logInfo("UI Test: Set source to \(testSourcePath)")
+        }
+
+        destinationManager.loadUITestDestinations()
+
+        // Load test organization name if provided
+        if let testOrgName = UserDefaults.standard.string(forKey: "TestOrganizationName") {
+            organizationName = testOrgName
+            logInfo("UI Test: Set organization name to \(testOrgName)")
+        }
+
+        // Clear source test values (destination keys cleared by DestinationManager)
+        UserDefaults.standard.removeObject(forKey: "TestSourcePath")
+        UserDefaults.standard.removeObject(forKey: "TestOrganizationName")
+        #else
+        // Release builds: never honor UI-test UserDefaults overrides.
+        destinationManager.initializeEmpty()
+        #endif
+    }
+}

--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -46,18 +46,8 @@ class BackupManager {
     // Transient per-run backup state extracted into BackupState (#103 decomposition).
     let state = BackupState()
 
-    // Modal-presentation flags forwarded to state so $backupManager.showX bindings keep working.
-    var showCompletionReport: Bool { get { state.showCompletionReport } set { state.showCompletionReport = newValue } }
-    var showMigrationDialog: Bool { get { state.showMigrationDialog } set { state.showMigrationDialog = newValue } }
-    var showDuplicateWarning: Bool { get { state.showDuplicateWarning } set { state.showDuplicateWarning = newValue } }
-    var showTrashConfirmation: Bool { get { state.showTrashConfirmation } set { state.showTrashConfirmation = newValue } }
-    var showLargeBackupConfirmation: Bool { get { state.showLargeBackupConfirmation } set { state.showLargeBackupConfirmation = newValue } }
-
-    // MARK: - Destination Forwarding (read-only)
-
-    var destinationURLs: [URL?] { destinationManager.destinationURLs }
-    var destinationItems: [DestinationItem] { destinationManager.destinationItems }
-    var destinationDriveInfo: [UUID: DriveAnalyzer.DriveInfo] { destinationManager.destinationDriveInfo }
+    // Modal-presentation flags, destination/source forwarding, and delegated
+    // scanning/progress accessors live in BackupManager+Forwarding.swift (AMUX-230).
 
     // Progress tracking delegated to ProgressTracker.
     // AMUX-206: `var` (not `let`) so runBackup can swap in a fresh instance per
@@ -74,35 +64,6 @@ class BackupManager {
 
     // Resource management
     let resourceManager = ResourceManager() // Made internal for extension access
-
-    // Source-related properties are now on sourceManager
-    // Convenience accessors for code that still reads these directly
-    var sourceURL: URL? {
-        get { sourceManager.sourceURL }
-        set { sourceManager.sourceURL = newValue }
-    }
-    var sourceFileTypes: [ImageFileType: Int] {
-        get { sourceManager.sourceFileTypes }
-        set { sourceManager.sourceFileTypes = newValue }
-    }
-    var isScanning: Bool { sourceManager.isScanning }
-    var scanProgress: String {
-        get { sourceManager.scanProgress }
-        set { sourceManager.scanProgress = newValue }
-    }
-    var sourceTotalBytes: Int64 { sourceManager.sourceTotalBytes }
-    var fileTypeFilter: FileTypeFilter {
-        get { sourceManager.fileTypeFilter }
-        set { sourceManager.fileTypeFilter = newValue }
-    }
-    var includeSubdirectories: Bool {
-        get { sourceManager.includeSubdirectories }
-        set { sourceManager.includeSubdirectories = newValue }
-    }
-    var excludeCacheFiles: Bool {
-        get { sourceManager.excludeCacheFiles }
-        set { sourceManager.excludeCacheFiles = newValue }
-    }
 
     // Backup organization
     // Custom folder name for organizing backups.
@@ -262,40 +223,7 @@ class BackupManager {
         destinationManager.removeDestination(at: index)
     }
 
-    // MARK: - UI Test Support
-
-    private func loadUITestPaths() {
-        // The TestSourcePath / TestOrganizationName UserDefaults overrides are
-        // for UI testing only. Wrap in #if DEBUG so a malicious local process
-        // can't `defaults write` an arbitrary path into a Full-Disk-Access-
-        // granted release build to coerce the app into reading protected files.
-        #if DEBUG
-        logInfo("Loading UI test paths")
-
-        // Load test source path
-        if let testSourcePath = UserDefaults.standard.string(forKey: "TestSourcePath") {
-            let sourceURL = URL(fileURLWithPath: testSourcePath)
-            self.sourceManager.sourceURL = sourceURL
-            organizationName = SmartFolderName.from(url: sourceURL)
-            logInfo("UI Test: Set source to \(testSourcePath)")
-        }
-
-        destinationManager.loadUITestDestinations()
-
-        // Load test organization name if provided
-        if let testOrgName = UserDefaults.standard.string(forKey: "TestOrganizationName") {
-            organizationName = testOrgName
-            logInfo("UI Test: Set organization name to \(testOrgName)")
-        }
-
-        // Clear source test values (destination keys cleared by DestinationManager)
-        UserDefaults.standard.removeObject(forKey: "TestSourcePath")
-        UserDefaults.standard.removeObject(forKey: "TestOrganizationName")
-        #else
-        // Release builds: never honor UI-test UserDefaults overrides.
-        destinationManager.initializeEmpty()
-        #endif
-    }
+    // loadUITestPaths lives in BackupManager+UITestSupport.swift (AMUX-230).
 
     func canRunBackup() -> Bool {
         return sourceURL != nil
@@ -393,44 +321,7 @@ class BackupManager {
         }
     }
 
-    /// Build the data snapshot the preflight presenter needs.
-    /// Pure data construction — no UI. Pulled out so runBackup is easy to read
-    /// and the summary construction is testable in isolation.
-    private func buildPreflightSummary(source: URL, destinations: [URL]) -> PreflightSummary {
-        // Filtered summary (when a file-type filter is active).
-        let filteredSummary = getFilteredFilesSummary()
-
-        // Non-filtered file count and type summary (used when no filter is active).
-        let nonFilteredTotalFiles = sourceFileTypes.values.reduce(0, +)
-        let nonFilteredTypeSummary: String? = sourceFileTypes.isEmpty ? nil : getFormattedFileTypeSummary()
-
-        // Build destination tuples with optional drive device names.
-        // Zip the raw parallel arrays before filtering nils so indices stay aligned:
-        // compactMap on destinationURLs alone would shift the index into
-        // destinationItems if any earlier slot is nil.
-        let validPairs: [(URL, DestinationItem)] = zip(destinationURLs, destinationItems).compactMap { url, item in
-            guard let url = url else { return nil }
-            return (url, item)
-        }
-        let destTuples: [(name: String, deviceName: String?)] = validPairs.map { url, item in
-            let deviceName = destinationDriveInfo[item.id]?.deviceName
-            let resolvedDeviceName = (deviceName?.isEmpty == false) ? deviceName : nil
-            return (name: url.lastPathComponent, deviceName: resolvedDeviceName)
-        }
-
-        return PreflightSummary(
-            sourceName: source.lastPathComponent,
-            sourcePath: source.path,
-            filteredSummary: filteredSummary,
-            fileTypeSummary: nonFilteredTypeSummary,
-            totalFiles: nonFilteredTotalFiles,
-            totalBytes: sourceTotalBytes,
-            destinations: destTuples,
-            excludeCacheFiles: preferences.excludeCacheFiles,
-            skipHiddenFiles: preferences.skipHiddenFiles,
-            fileTypeFilterActive: !fileTypeFilter.includedExtensions.isEmpty
-        )
-    }
+    // buildPreflightSummary lives in BackupManager+Preflight.swift (AMUX-230).
 
     func cancelOperation() {
         guard !state.shouldCancel else { return } // Prevent multiple cancellations
@@ -537,44 +428,6 @@ class BackupManager {
         }
     }
 
-    // MARK: - Source Tag Delegation
-
-    func checkForSourceTag(at url: URL) -> Bool {
-        sourceManager.checkForSourceTag(at: url)
-    }
-
-    // MARK: - Progress Forwarding
-
-    func formattedETA() -> String {
-        return progressTracker.formattedETA()
-    }
-
-    @MainActor
-    func initializeDestinations(_ destinations: [URL]) async {
-        progressTracker.initializeDestinations(destinations)
-    }
-
-    @MainActor
-    func incrementDestinationProgress(_ destinationName: String) {
-        _ = progressTracker.incrementDestinationProgress(destinationName)
-    }
-
-    // MARK: - File Scanning (delegated to SourceManager)
-
-    func getFormattedFileTypeSummary(groupRaw: Bool = false) -> String {
-        sourceManager.getFormattedFileTypeSummary(groupRaw: groupRaw)
-    }
-
-    func getFilteredFilesSummary() -> (summary: String, willCopy: Int, total: Int)? {
-        sourceManager.getFilteredFilesSummary()
-    }
-
-    func getDestinationEstimate(at index: Int) -> String? {
-        destinationManager.getDestinationEstimate(at: index, sourceState: SourceEstimateState(
-            sourceURL: sourceManager.sourceURL,
-            sourceTotalBytes: sourceManager.sourceTotalBytes,
-            sourceFileTypes: sourceManager.sourceFileTypes,
-            isScanning: sourceManager.isScanning
-        ))
-    }
+    // Source-tag, progress, and file-scanning delegation live in
+    // BackupManager+Forwarding.swift (AMUX-230).
 }

--- a/ImageIntact/Models/BackupManagerQueueIntegration.swift
+++ b/ImageIntact/Models/BackupManagerQueueIntegration.swift
@@ -355,46 +355,7 @@ extension BackupManager {
         statistics.completeBackup()
     }
 
-    /// Handle backup completion (notifications and UI).
-    /// `internal` (not `private`) so tests can drive it directly with mocked
-    /// `preferences` / `notificationService` and assert which prefs reads gate
-    /// which side effects (AMUX-205 panel review round 4).
-    @MainActor
-    func handleBackupCompletion(destinations: [URL]) async {
-        // Stop preventing sleep
-        SleepPrevention.shared.stopPreventingSleep()
-
-        // Show completion report if not cancelled
-        if !state.shouldCancel {
-            // Send notification if enabled
-            if preferences.showNotificationOnComplete {
-                notificationService.sendBackupCompletionNotification(
-                    filesCopied: progressTracker.processedFiles,
-                    destinations: destinations.count,
-                    duration: statistics.duration ?? 0
-                )
-            }
-
-            // Small delay to ensure UI is ready
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            showCompletionReport = true
-
-            // Offer to trash source if enabled and backup was fully successful
-            if preferences.trashSourceAfterBackup
-                && state.failedFiles.isEmpty
-                && sourceURL != nil
-            {
-                showTrashConfirmation = true
-            }
-        } else {
-            // Clear the overall status text when cancelled
-            state.overallStatusText = ""
-            state.statusMessage = "Backup cancelled"
-
-            // Still stop sleep prevention even if cancelled
-            logInfo("Backup cancelled by user")
-        }
-    }
+    // handleBackupCompletion lives in BackupManager+Completion.swift (AMUX-230).
 
     // MARK: - Migration Support
 
@@ -516,87 +477,6 @@ extension BackupManager {
         state.statusMessage = "Backup cancelled"
     }
 
-    // MARK: - Large Backup Confirmation
-
-    /// Check if this is a large backup and wait for user confirmation if needed.
-    /// Returns true if backup should proceed, false if user cancelled.
-    /// `internal` (not `private`) so tests can drive the early-return branches
-    /// directly and assert which prefs reads gate which behavior (AMUX-205
-    /// panel review round 4).
-    @MainActor
-    func checkForLargeBackupAndWait(
-        source _: URL, destinations: [URL], manifest: [FileManifestEntry]
-    ) async -> Bool {
-        ApplicationLogger.shared.debug(
-            "Checking for large backup (threshold: \(preferences.largeBackupFileThreshold) files / \(preferences.largeBackupSizeThresholdGB) GB)",
-            category: .backup
-        )
-
-        // Skip if user disabled confirmations or already disabled warnings
-        guard
-            preferences.confirmLargeBackups
-            && !preferences.skipLargeBackupWarning
-        else {
-            return true // Proceed with backup
-        }
-
-        // Check for cancellation
-        guard !state.shouldCancel else { return false }
-
-        state.statusMessage = "Analyzing backup size..."
-
-        let fileThreshold = preferences.largeBackupFileThreshold
-        let sizeThresholdBytes = Int64(
-            preferences.largeBackupSizeThresholdGB * 1_000_000_000)
-        let totalBytes = manifest.reduce(0) { $0 + $1.size }
-
-        // Check if backup exceeds thresholds
-        guard manifest.count > fileThreshold || totalBytes > sizeThresholdBytes else {
-            return true // Proceed with backup
-        }
-
-        ApplicationLogger.shared.debug(
-            "Large backup detected: \(manifest.count) files, \(String(format: "%.1f", Double(totalBytes) / 1_000_000_000)) GB",
-            category: .backup
-        )
-
-        // Calculate estimated time
-        let estimatedSpeed = 50.0 // MB/s - conservative estimate
-        let seconds = Double(totalBytes) / (estimatedSpeed * 1_000_000)
-        let timeString = TimeFormatter.formatDuration(seconds)
-
-        state.largeBackupInfo = BackupState.LargeBackupInfo(
-            fileCount: manifest.count,
-            totalBytes: totalBytes,
-            destinationCount: destinations.count,
-            estimatedTimePerDestination: timeString
-        )
-        showLargeBackupConfirmation = true
-
-        // Wait for user response using CheckedContinuation
-        let result = await withCheckedContinuation { continuation in
-            state.largeBackupContinuation = continuation
-        }
-
-        return result
-    }
-
-    /// User responded to large backup confirmation
-    @MainActor
-    func respondToLargeBackupConfirmation(shouldContinue: Bool, dontShowAgain: Bool) {
-        showLargeBackupConfirmation = false
-        state.largeBackupInfo = nil
-
-        if dontShowAgain {
-            preferences.skipLargeBackupWarning = true
-        }
-
-        // Resume the waiting backup process
-        if let continuation = state.largeBackupContinuation {
-            continuation.resume(returning: shouldContinue)
-            state.largeBackupContinuation = nil
-        } else {
-            ApplicationLogger.shared.debug("No continuation to resume for large backup confirmation", category: .backup)
-        }
-    }
+    // checkForLargeBackupAndWait + respondToLargeBackupConfirmation live in
+    // BackupManager+LargeBackup.swift (AMUX-230).
 }


### PR DESCRIPTION
## Summary
- BackupManager.swift (580 lines) and BackupManagerQueueIntegration.swift (602 lines) exceeded the workspace-wide 500-line limit enforced by verify-code.sh, which warned on every edit.
- Pure code movement into five focused extension files; no behavioral changes:
  - `BackupManager+Forwarding.swift` — modal-presentation flags, destination/source forwarding accessors, progress + file-scanning delegation
  - `BackupManager+UITestSupport.swift` — `loadUITestPaths`
  - `BackupManager+Preflight.swift` — `buildPreflightSummary`
  - `BackupManager+Completion.swift` — `handleBackupCompletion`
  - `BackupManager+LargeBackup.swift` — `checkForLargeBackupAndWait` + `respondToLargeBackupConfirmation`
- Root files are now 433 and 482 lines.
- `loadUITestPaths` and `buildPreflightSummary` change `private` → `internal` because cross-file extensions can't see private members; doc comments note the intended visibility.

## Test plan
- [x] Baseline before refactor: 58/58 BackupManager* + PreferencesProviding tests passed on origin/main (89135cb)
- [x] After refactor: same suite 58/58 passed, `** TEST SUCCEEDED **`
- [x] Symbol audit: every moved declaration defined exactly once across the six files

AMUX-230 (followup to AMUX-205 panel review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)