### PR TITLE
Ignore .worktrees/ and .claude/ (AMUX-255)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ comprehensive-test-results.txt
 # macOS
 .DS_Store
 *.xcresult
+
+# Multi-session safety: worktrees and local Claude config must never be committed
+.worktrees/
+.claude/

--- a/Scripts/gitignore_test.sh
+++ b/Scripts/gitignore_test.sh
@@ -16,6 +16,23 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# --- Ignore case: .worktrees/ and .claude/ must be gitignored ---
+git -C "$repo_root" check-ignore -q .worktrees/ && {
+  echo "PASS: ignore case - .worktrees/ is gitignored"
+  PASS=$((PASS + 1))
+} || {
+  echo "FAIL: ignore case - .worktrees/ is NOT gitignored"
+  FAIL=$((FAIL + 1))
+}
+
+git -C "$repo_root" check-ignore -q .claude/ && {
+  echo "PASS: ignore case - .claude/ is gitignored"
+  PASS=$((PASS + 1))
+} || {
+  echo "FAIL: ignore case - .claude/ is NOT gitignored"
+  FAIL=$((FAIL + 1))
+}
+
 # --- Summary ---
 echo ""
 echo "Results: $((PASS + FAIL)) tests, $PASS passed, $FAIL failed"

--- a/Scripts/gitignore_test.sh
+++ b/Scripts/gitignore_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+repo_root="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+# --- Characterization: nothing under .claude or .worktrees is tracked ---
+char_output="$(git -C "$repo_root" ls-files .claude .worktrees)"
+if [[ -z "$char_output" ]]; then
+  echo "PASS: char case - .claude and .worktrees contain no tracked files"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: char case - unexpected tracked files: $char_output"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: $((PASS + FAIL)) tests, $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Problem

`git add -A` in the shared checkout could accidentally commit:
- A sibling session's worktree checkout (`.worktrees/`)
- Local Claude Code settings with session-specific config (`.claude/settings.local.json`)

Neither path was in `.gitignore`, making this a silent footgun in any multi-session workflow.

## Fix

Appended `.worktrees/` and `.claude/` to the repo-root `.gitignore`.

## Tests

Added `Scripts/gitignore_test.sh` with:
1. Characterization case: `git ls-files .claude .worktrees` produces no output (nothing tracked under either path)
2. Ignore case: `git check-ignore -q` confirms both paths are now gitignored

Ref: AMUX-255