### PR TITLE
Fix preflight decision dialog loop (gh#141)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -310,6 +310,14 @@ class BackupManager {
         state.sessionID = UUID().uuidString
         state.shouldCancel = false
         state.debugLog = []
+        // A fresh run must not inherit the prior run's duplicate decision:
+        // the analyses describe the old run's manifest and the skip flags
+        // belong to a dialog not yet answered this run. Cleared here (not in
+        // resetBackupState) because continuation re-entries bypass runBackup
+        // and need both to survive (gh#141). Values are BackupState defaults.
+        state.duplicateAnalyses = nil
+        state.skipExactDuplicates = true
+        state.skipRenamedDuplicates = false
 
         // Save organization folder name to recent list and as last used
         if !organizationName.isEmpty {

--- a/ImageIntact/Models/BackupManagerDecisionContinuation.swift
+++ b/ImageIntact/Models/BackupManagerDecisionContinuation.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+// MARK: - Preflight Decision Dialogs + Continuations
+//
+// Split out of BackupManagerQueueIntegration.swift (gh#141, 500-line limit).
+//
+// The migration and duplicate preflight checks pause the run and present a
+// decision sheet; the continuations below re-enter performQueueBasedBackup
+// once the user answers. The re-entry arms that method's skip flags for the
+// already-answered checks — the detectors have no decline-memory, so
+// re-running an answered check re-presents the same sheet forever (gh#141).
+
+extension BackupManager {
+    // MARK: - Migration Support
+
+    /// Check if migration is needed for organizing existing files.
+    /// internal (not private): called from performQueueBasedBackup in
+    /// BackupManagerQueueIntegration.swift.
+    @MainActor
+    func checkForMigration(source: URL, destinations: [URL], manifest: [FileManifestEntry])
+        async
+    {
+        ApplicationLogger.shared.debug("Checking for migration opportunities", category: .backup)
+
+        // Check for cancellation
+        guard !state.shouldCancel else {
+            ApplicationLogger.shared.debug("Migration check cancelled", category: .backup)
+            return
+        }
+
+        state.pendingMigrationPlans.removeAll()
+
+        // Start security-scoped access for source
+        let sourceAccessGranted = source.startAccessingSecurityScopedResource()
+        defer {
+            if sourceAccessGranted {
+                source.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let detector = BackupMigrationDetector()
+
+        // Check each destination for migration needs
+        for (_, destination) in destinations.enumerated() {
+            if let plan = await detector.checkForMigrationNeeded(
+                source: source,
+                destination: destination,
+                organizationName: organizationName,
+                manifest: manifest
+            ) {
+                ApplicationLogger.shared.debug("Migration needed for \(destination.lastPathComponent): \(plan.fileCount) files", category: .backup)
+                state.pendingMigrationPlans.append(plan)
+            }
+        }
+
+        // Show migration dialog if needed
+        if !state.pendingMigrationPlans.isEmpty {
+            showMigrationDialog = true
+        }
+    }
+
+    /// Continue backup after migration decision.
+    /// Re-enters with skipMigrationCheck armed: the user just answered the
+    /// offer (Organize or Skip), and after Skip the org folder is still
+    /// absent, so a re-run check would re-present the sheet (gh#141). The
+    /// duplicate check still runs — that dialog has not been shown yet at
+    /// this point in the chain.
+    @MainActor
+    func continueBackupAfterMigration() async {
+        ApplicationLogger.shared.debug("Continuing backup after migration", category: .backup)
+        showMigrationDialog = false
+        state.pendingMigrationPlans.removeAll()
+
+        // Re-run the backup now that migration is handled
+        if let source = sourceURL {
+            let destinations = destinationItems.compactMap { $0.url }
+            await performQueueBasedBackup(
+                source: source,
+                destinations: destinations,
+                skipMigrationCheck: true
+            )
+        }
+    }
+
+    // MARK: - Duplicate Support
+
+    /// Check for duplicate files at destinations.
+    /// internal (not private): called from performQueueBasedBackup in
+    /// BackupManagerQueueIntegration.swift.
+    @MainActor
+    func checkForDuplicates(source _: URL, destinations: [URL], manifest: [FileManifestEntry])
+        async
+    {
+        ApplicationLogger.shared.debug("Checking for duplicate files", category: .backup)
+
+        // Check for cancellation
+        guard !state.shouldCancel else {
+            ApplicationLogger.shared.debug("Duplicate check cancelled", category: .backup)
+            return
+        }
+
+        state.statusMessage = "Analyzing for duplicates..."
+
+        // Perform duplicate analysis for all destinations
+        let analyses = await duplicateDetector.preflightDuplicateCheck(
+            manifest: manifest,
+            destinations: destinations,
+            organizationName: organizationName
+        )
+
+        // Check if any duplicates were found
+        let totalDuplicates = analyses.values.reduce(0) { $0 + $1.totalDuplicates }
+
+        if totalDuplicates > 0 {
+            ApplicationLogger.shared.debug("Found \(totalDuplicates) duplicate files across destinations", category: .backup)
+            state.duplicateAnalyses = analyses
+            showDuplicateWarning = true
+        } else {
+            ApplicationLogger.shared.debug("No duplicates found", category: .backup)
+            state.duplicateAnalyses = nil
+            showDuplicateWarning = false
+        }
+    }
+
+    /// Continue backup after duplicate handling decision.
+    /// Re-enters with BOTH skip flags armed: the duplicate sheet only appears
+    /// after the migration question is resolved, so a re-run migration check
+    /// would re-present it (migration-skip → duplicate chain), and the
+    /// analysis the user decided on is retained in state.duplicateAnalyses
+    /// for the orchestrator (gh#141).
+    @MainActor
+    func continueBackupAfterDuplicateDecision(skipExact: Bool, skipRenamed: Bool) async {
+        ApplicationLogger.shared.debug("Continuing backup with duplicate preferences", category: .backup)
+        showDuplicateWarning = false
+        state.skipExactDuplicates = skipExact
+        state.skipRenamedDuplicates = skipRenamed
+
+        // Re-run the backup now that duplicate handling is decided
+        if let source = sourceURL {
+            let destinations = destinationItems.compactMap { $0.url }
+            await performQueueBasedBackup(
+                source: source,
+                destinations: destinations,
+                skipMigrationCheck: true,
+                skipDuplicateCheck: true
+            )
+        }
+    }
+
+    /// Cancel backup from duplicate warning
+    @MainActor
+    func cancelBackupFromDuplicateWarning() {
+        ApplicationLogger.shared.debug("Backup cancelled by user from duplicate warning", category: .backup)
+        showDuplicateWarning = false
+        state.duplicateAnalyses = nil
+        state.isProcessing = false
+        state.statusMessage = "Backup cancelled"
+    }
+}

--- a/ImageIntact/Models/BackupManagerDecisionContinuation.swift
+++ b/ImageIntact/Models/BackupManagerDecisionContinuation.swift
@@ -79,6 +79,14 @@ extension BackupManager {
                 destinations: destinations,
                 skipMigrationCheck: true
             )
+        } else {
+            // Should be unreachable (the dialog was armed by a run that had
+            // a source), but don't strand the just-dismissed dialog: land in
+            // a clean idle state instead of silently dropping the decision.
+            ApplicationLogger.shared.error(
+                "Migration continuation found no source URL - returning to idle", category: .backup)
+            state.isProcessing = false
+            state.statusMessage = "Backup cancelled"
         }
     }
 
@@ -144,6 +152,15 @@ extension BackupManager {
                 skipMigrationCheck: true,
                 skipDuplicateCheck: true
             )
+        } else {
+            // Should be unreachable (the dialog was armed by a run that had
+            // a source), but don't strand the just-dismissed dialog: land in
+            // a clean idle state instead of silently dropping the decision.
+            ApplicationLogger.shared.error(
+                "Duplicate continuation found no source URL - returning to idle", category: .backup)
+            state.duplicateAnalyses = nil
+            state.isProcessing = false
+            state.statusMessage = "Backup cancelled"
         }
     }
 

--- a/ImageIntact/Models/BackupManagerQueueIntegration.swift
+++ b/ImageIntact/Models/BackupManagerQueueIntegration.swift
@@ -14,8 +14,21 @@ public struct FileManifestEntry {
 extension BackupManager {
     /// Performs backup using the new smart queue system with BackupOrchestrator
     /// Each destination runs independently at its own speed
+    ///
+    /// The skip flags are per-run decision memory (gh#141): decision
+    /// continuations re-enter this method after the user answers a preflight
+    /// dialog, and the answered check must not re-run — the detectors have no
+    /// decline-memory, so re-running re-presents the same sheet forever.
+    /// Passing the memory as parameters (not state) scopes it to the
+    /// re-entry chain by construction: a fresh Run Backup uses the defaults
+    /// and both checks run again.
     @MainActor
-    func performQueueBasedBackup(source: URL, destinations: [URL]) async {
+    func performQueueBasedBackup(
+        source: URL,
+        destinations: [URL],
+        skipMigrationCheck: Bool = false,
+        skipDuplicateCheck: Bool = false
+    ) async {
         let backupID = UUID().uuidString.prefix(8)
         ApplicationLogger.shared.debug(
             "Starting backup \(backupID): \(source.lastPathComponent) → \(destinations.count) destination(s)",
@@ -79,8 +92,9 @@ extension BackupManager {
         // Yield control to UI after manifest building
         await Task.yield()
 
-        // Check for migration if organization is enabled
-        if !organizationName.isEmpty {
+        // Check for migration if organization is enabled and the user hasn't
+        // already answered the offer this run
+        if !organizationName.isEmpty, !skipMigrationCheck {
             await checkForMigration(
                 source: source, destinations: destinations, manifest: preflightManifest
             )
@@ -98,8 +112,9 @@ extension BackupManager {
             }
         }
 
-        // Check for duplicates before proceeding
-        if enableDuplicateDetection {
+        // Check for duplicates before proceeding, unless the user has
+        // already made the call for this run
+        if enableDuplicateDetection, !skipDuplicateCheck {
             await checkForDuplicates(
                 source: source, destinations: destinations, manifest: preflightManifest
             )
@@ -363,125 +378,8 @@ extension BackupManager {
 
     // handleBackupCompletion lives in BackupManager+Completion.swift (AMUX-230).
 
-    // MARK: - Migration Support
-
-    /// Check if migration is needed for organizing existing files
-    @MainActor
-    private func checkForMigration(source: URL, destinations: [URL], manifest: [FileManifestEntry])
-        async
-    {
-        ApplicationLogger.shared.debug("Checking for migration opportunities", category: .backup)
-
-        // Check for cancellation
-        guard !state.shouldCancel else {
-            ApplicationLogger.shared.debug("Migration check cancelled", category: .backup)
-            return
-        }
-
-        state.pendingMigrationPlans.removeAll()
-
-        // Start security-scoped access for source
-        let sourceAccessGranted = source.startAccessingSecurityScopedResource()
-        defer {
-            if sourceAccessGranted {
-                source.stopAccessingSecurityScopedResource()
-            }
-        }
-
-        let detector = BackupMigrationDetector()
-
-        // Check each destination for migration needs
-        for (_, destination) in destinations.enumerated() {
-            if let plan = await detector.checkForMigrationNeeded(
-                source: source,
-                destination: destination,
-                organizationName: organizationName,
-                manifest: manifest
-            ) {
-                ApplicationLogger.shared.debug("Migration needed for \(destination.lastPathComponent): \(plan.fileCount) files", category: .backup)
-                state.pendingMigrationPlans.append(plan)
-            }
-        }
-
-        // Show migration dialog if needed
-        if !state.pendingMigrationPlans.isEmpty {
-            showMigrationDialog = true
-        }
-    }
-
-    /// Continue backup after migration decision
-    @MainActor
-    func continueBackupAfterMigration() async {
-        ApplicationLogger.shared.debug("Continuing backup after migration", category: .backup)
-        showMigrationDialog = false
-
-        // Re-run the backup now that migration is handled
-        if let source = sourceURL {
-            let destinations = destinationItems.compactMap { $0.url }
-            await performQueueBasedBackup(source: source, destinations: destinations)
-        }
-    }
-
-    /// Check for duplicate files at destinations
-    @MainActor
-    private func checkForDuplicates(source _: URL, destinations: [URL], manifest: [FileManifestEntry])
-        async
-    {
-        ApplicationLogger.shared.debug("Checking for duplicate files", category: .backup)
-
-        // Check for cancellation
-        guard !state.shouldCancel else {
-            ApplicationLogger.shared.debug("Duplicate check cancelled", category: .backup)
-            return
-        }
-
-        state.statusMessage = "Analyzing for duplicates..."
-
-        // Perform duplicate analysis for all destinations
-        let analyses = await duplicateDetector.preflightDuplicateCheck(
-            manifest: manifest,
-            destinations: destinations,
-            organizationName: organizationName
-        )
-
-        // Check if any duplicates were found
-        let totalDuplicates = analyses.values.reduce(0) { $0 + $1.totalDuplicates }
-
-        if totalDuplicates > 0 {
-            ApplicationLogger.shared.debug("Found \(totalDuplicates) duplicate files across destinations", category: .backup)
-            state.duplicateAnalyses = analyses
-            showDuplicateWarning = true
-        } else {
-            ApplicationLogger.shared.debug("No duplicates found", category: .backup)
-            state.duplicateAnalyses = nil
-            showDuplicateWarning = false
-        }
-    }
-
-    /// Continue backup after duplicate handling decision
-    @MainActor
-    func continueBackupAfterDuplicateDecision(skipExact: Bool, skipRenamed: Bool) async {
-        ApplicationLogger.shared.debug("Continuing backup with duplicate preferences", category: .backup)
-        showDuplicateWarning = false
-        state.skipExactDuplicates = skipExact
-        state.skipRenamedDuplicates = skipRenamed
-
-        // Re-run the backup now that duplicate handling is decided
-        if let source = sourceURL {
-            let destinations = destinationItems.compactMap { $0.url }
-            await performQueueBasedBackup(source: source, destinations: destinations)
-        }
-    }
-
-    /// Cancel backup from duplicate warning
-    @MainActor
-    func cancelBackupFromDuplicateWarning() {
-        ApplicationLogger.shared.debug("Backup cancelled by user from duplicate warning", category: .backup)
-        showDuplicateWarning = false
-        state.duplicateAnalyses = nil
-        state.isProcessing = false
-        state.statusMessage = "Backup cancelled"
-    }
+    // checkForMigration / checkForDuplicates and their decision continuations
+    // live in BackupManagerDecisionContinuation.swift (gh#141, 500-line limit).
 
     // checkForLargeBackupAndWait + respondToLargeBackupConfirmation live in
     // BackupManager+LargeBackup.swift (AMUX-230).

--- a/ImageIntactTests/BackupManagerDecisionContinuationTests.swift
+++ b/ImageIntactTests/BackupManagerDecisionContinuationTests.swift
@@ -1,0 +1,252 @@
+//
+//  BackupManagerDecisionContinuationTests.swift
+//  ImageIntactTests
+//
+//  gh#141 (AMUX-391): the migration-Skip and duplicate-Continue decision
+//  continuations re-enter performQueueBasedBackup, which re-runs the same
+//  preflight check with no memory of the decision just made — the sheet
+//  re-presents forever and the backup never runs. With duplicate detection
+//  enabled, Cancel is the only working exit.
+//
+//  These tests drive the real preflight: fixtures live under
+//  temporaryDirectory/imageintact-uitest/ so the pipeline's security-scope
+//  guards accept them via UITestSeam.allowsUnscopedAccess (the same
+//  DEBUG-only marker-path escape the UI suite uses). The migration trigger
+//  is the real BackupMigrationDetector (not injectable) against
+//  byte-identical same-name files at the destination root; the duplicate
+//  trigger is MockDuplicateDetector.shouldReturnDuplicates, which reports a
+//  duplicate on EVERY pass — exactly the re-check condition that loops
+//  today. Only per-run decision memory breaks the loop.
+//
+//  Design: .planning/design/backup-manager-queue-integration-decision-memory.md
+//
+
+import XCTest
+
+@testable import ImageIntact
+
+@MainActor
+final class BackupManagerDecisionContinuationTests: BaseBackupManagerTestCase {
+
+  private var fixtureRoot: URL!
+  private var sourceDir: URL!
+  private var destDir: URL!
+  private var prefs: InMemoryPreferencesProvider!
+  private var mockDuplicates: MockDuplicateDetector!
+
+  override func setUp() async throws {
+    try await super.setUp()
+
+    // <tmp>/imageintact-uitest/<uuid>/{src,dest1} — the marker must be the
+    // path itself, parent, or grandparent for the seam to arm, so the unique
+    // per-test dir sits directly under the marker.
+    fixtureRoot = FileManager.default.temporaryDirectory
+      .appendingPathComponent("imageintact-uitest", isDirectory: true)
+      .appendingPathComponent("decision-\(UUID().uuidString.prefix(8))", isDirectory: true)
+    sourceDir = fixtureRoot.appendingPathComponent("src", isDirectory: true)
+    destDir = fixtureRoot.appendingPathComponent("dest1", isDirectory: true)
+    try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
+
+    try Data(repeating: 0xA1, count: 1024).write(to: sourceDir.appendingPathComponent("one.jpg"))
+    try Data(repeating: 0xB2, count: 2048).write(to: sourceDir.appendingPathComponent("two.jpg"))
+
+    prefs = InMemoryPreferencesProvider(showNotificationOnComplete: false)
+    mockDuplicates = MockDuplicateDetector()
+  }
+
+  override func tearDown() async throws {
+    // Base tearDown cancels any in-flight backup before bm is released.
+    try await super.tearDown()
+    if let fixtureRoot {
+      try? FileManager.default.removeItem(at: fixtureRoot)
+    }
+    mockDuplicates = nil
+    prefs = nil
+    destDir = nil
+    sourceDir = nil
+    fixtureRoot = nil
+  }
+
+  /// Builds the manager under test and points it at the fixture tree.
+  /// `setSource` auto-derives organizationName from the path, so the desired
+  /// value is applied AFTER it.
+  private func makeManager(organization: String) -> BackupManager {
+    let manager = BackupManager(
+      duplicateDetector: mockDuplicates,
+      backupAlertPresenter: MockBackupAlertPresenter(),
+      preferences: prefs
+    )
+    manager.setSource(sourceDir)
+    manager.setDestination(destDir, at: 0)
+    manager.organizationName = organization
+    return manager
+  }
+
+  /// Enters the backup the way `runBackup` does — source and destinations
+  /// derived from the manager's own stored items, so the continuation's
+  /// re-entry (which derives them the same way) produces IDENTICAL URLs.
+  /// The orchestrator looks up `duplicateAnalyses[destination]` by URL key;
+  /// a test-constructed URL can differ in standardization (/var vs
+  /// /private/var) and silently miss that lookup.
+  private func startBackup() async throws {
+    let source = try XCTUnwrap(bm.sourceURL, "setSource must have stored the source URL")
+    let destinations = bm.destinationItems.compactMap { $0.url }
+    XCTAssertFalse(destinations.isEmpty, "setDestination must have stored the destination URL")
+    await bm.performQueueBasedBackup(source: source, destinations: destinations)
+  }
+
+  /// Byte-identical, same-name copies at the destination ROOT with no
+  /// organization folder — exactly what BackupMigrationDetector flags.
+  private func prefillLooseRootFiles() throws {
+    for name in ["one.jpg", "two.jpg"] {
+      try FileManager.default.copyItem(
+        at: sourceDir.appendingPathComponent(name),
+        to: destDir.appendingPathComponent(name)
+      )
+    }
+  }
+
+  // MARK: - Migration Skip
+
+  /// INTENDED: declining the move proceeds with the backup — files are copied
+  /// into the organization folder, the offer does not re-appear for this run.
+  /// ACTUAL (gh#141): the continuation re-enters the preflight, which
+  /// re-detects the same loose root files and re-arms the dialog forever.
+  func testSkipMigration_DoesNotRepresentDialog_AndBackupProceeds() async throws {
+    try prefillLooseRootFiles()
+    bm = makeManager(organization: "TestOrg")
+
+    try await startBackup()
+
+    // Sanity: a fresh run must arm the migration offer.
+    XCTAssertTrue(bm.showMigrationDialog, "fresh run must detect loose root files and offer migration")
+    XCTAssertFalse(bm.state.pendingMigrationPlans.isEmpty, "a migration plan must be pending")
+    XCTAssertFalse(bm.state.isProcessing, "run must pause while waiting for the decision")
+
+    await bm.continueBackupAfterMigration()
+
+    XCTAssertFalse(
+      bm.showMigrationDialog,
+      "gh#141: the migration offer must NOT re-present after the user declined it")
+    XCTAssertTrue(
+      FileManager.default.fileExists(
+        atPath: destDir.appendingPathComponent("TestOrg/one.jpg").path),
+      "backup must proceed after Skip — files copied into the organization folder")
+    XCTAssertTrue(
+      FileManager.default.fileExists(
+        atPath: destDir.appendingPathComponent("TestOrg/two.jpg").path),
+      "backup must proceed after Skip — files copied into the organization folder")
+    XCTAssertTrue(
+      FileManager.default.fileExists(atPath: destDir.appendingPathComponent("one.jpg").path),
+      "Skip leaves loose root files in place (declined the move)")
+  }
+
+  // MARK: - Duplicate Continue
+
+  /// INTENDED: an explicit proceed decision runs the backup honoring the skip
+  /// flags, with no re-analysis and no re-presented warning.
+  /// ACTUAL (gh#141): the continuation re-enters the preflight, which re-runs
+  /// the duplicate analysis (the mock reports duplicates every time, as the
+  /// real Core-Data-backed detector does) and re-arms the warning forever.
+  ///
+  /// The mock analysis pins one.jpg's REAL checksum (the orchestrator filters
+  /// per-destination manifests by checksum — `shouldReturnDuplicates`
+  /// hard-codes "abc123", which matches nothing and filters nothing), so the
+  /// post-decision copy result proves the selection was honored end to end.
+  func testContinueAfterDuplicateDecision_DoesNotReanalyzeOrRepresentDialog() async throws {
+    prefs.enableSmartDuplicateDetection = true
+    let duplicateURL = sourceDir.appendingPathComponent("one.jpg")
+    let duplicateChecksum = try ChecksumService.sha256(for: duplicateURL, shouldCancel: { false })
+    mockDuplicates.mockAnalysis = DuplicateDetector.DuplicateAnalysis(
+      totalSourceFiles: 2,
+      exactDuplicates: [
+        DuplicateDetector.DuplicateFile(
+          sourceFile: FileManifestEntry(
+            relativePath: "one.jpg",
+            sourceURL: duplicateURL,
+            checksum: duplicateChecksum,
+            size: 1024
+          ),
+          destinationPath: destDir.appendingPathComponent("one.jpg").path,
+          checksum: duplicateChecksum,
+          isDifferentName: false,
+          existingOrganization: nil
+        )
+      ],
+      renamedDuplicates: [],
+      uniqueFiles: 1,
+      potentialSpaceSaved: 1024,
+      destinationDriveUUID: nil
+    )
+    bm = makeManager(organization: "")  // no organization → migration check never arms
+
+    try await startBackup()
+
+    // Sanity: a fresh run must arm the duplicate warning.
+    XCTAssertTrue(bm.showDuplicateWarning, "fresh run must surface the duplicate warning")
+    XCTAssertNotNil(bm.state.duplicateAnalyses, "analyses must be retained for the decision")
+    XCTAssertEqual(mockDuplicates.analyzeCallCount, 1, "one analysis per destination on the fresh run")
+    XCTAssertFalse(bm.state.isProcessing, "run must pause while waiting for the decision")
+
+    await bm.continueBackupAfterDuplicateDecision(skipExact: true, skipRenamed: false)
+
+    XCTAssertFalse(
+      bm.showDuplicateWarning,
+      "gh#141: the duplicate warning must NOT re-present after an explicit proceed decision")
+    XCTAssertEqual(
+      mockDuplicates.analyzeCallCount, 1,
+      "gh#141: the continuation must not re-run the duplicate analysis — the decision was made on the first pass")
+    XCTAssertFalse(bm.state.isProcessing, "backup must have run to completion")
+    // skipExact filters the flagged duplicate (one.jpg); the other file must
+    // actually land at the destination root (no organization).
+    let copied = try FileManager.default.contentsOfDirectory(atPath: destDir.path)
+      .filter { $0.hasSuffix(".jpg") }
+    XCTAssertEqual(
+      copied, ["two.jpg"],
+      "backup must proceed honoring the selection: one.jpg skipped, two.jpg copied")
+  }
+
+  // MARK: - Migration → Duplicate chain
+
+  /// Decision memory is per-dialog, not global: skipping the migration offer
+  /// must still surface the not-yet-seen duplicate warning, and the duplicate
+  /// decision must then run the backup without re-presenting EITHER dialog.
+  func testMigrationSkipThenDuplicateDecision_ChainPresentsEachDialogOnce() async throws {
+    try prefillLooseRootFiles()
+    prefs.enableSmartDuplicateDetection = true
+    mockDuplicates.shouldReturnDuplicates = true
+    bm = makeManager(organization: "TestOrg")
+
+    try await startBackup()
+
+    // Migration is checked first; the run pauses before duplicate analysis.
+    XCTAssertTrue(bm.showMigrationDialog, "fresh run must offer migration first")
+    XCTAssertFalse(bm.showDuplicateWarning, "duplicate analysis must not have run yet")
+    XCTAssertEqual(mockDuplicates.analyzeCallCount, 0)
+
+    await bm.continueBackupAfterMigration()
+
+    XCTAssertFalse(
+      bm.showMigrationDialog,
+      "gh#141: the declined migration offer must not re-present")
+    XCTAssertTrue(
+      bm.showDuplicateWarning,
+      "the duplicate warning has not been decided yet — the migration decision must not suppress it")
+    XCTAssertEqual(mockDuplicates.analyzeCallCount, 1)
+
+    await bm.continueBackupAfterDuplicateDecision(skipExact: false, skipRenamed: false)
+
+    XCTAssertFalse(bm.showMigrationDialog, "no dialog may re-present after both decisions")
+    XCTAssertFalse(bm.showDuplicateWarning, "no dialog may re-present after both decisions")
+    XCTAssertEqual(mockDuplicates.analyzeCallCount, 1, "Copy All Anyway must not re-analyze")
+    XCTAssertTrue(
+      FileManager.default.fileExists(
+        atPath: destDir.appendingPathComponent("TestOrg/one.jpg").path),
+      "backup must run to completion after the chain of decisions")
+    XCTAssertTrue(
+      FileManager.default.fileExists(
+        atPath: destDir.appendingPathComponent("TestOrg/two.jpg").path),
+      "backup must run to completion after the chain of decisions")
+  }
+}

--- a/ImageIntactTests/BackupManagerDecisionContinuationTests.swift
+++ b/ImageIntactTests/BackupManagerDecisionContinuationTests.swift
@@ -249,4 +249,83 @@ final class BackupManagerDecisionContinuationTests: BaseBackupManagerTestCase {
         atPath: destDir.appendingPathComponent("TestOrg/two.jpg").path),
       "backup must run to completion after the chain of decisions")
   }
+
+  // MARK: - Fresh-run state hygiene
+
+  /// A fresh Run Backup must not inherit the prior run's duplicate decision:
+  /// the analyses describe the old run's manifest and the skip flags belong
+  /// to a dialog the user has not answered this run. The continuation
+  /// re-entry path must NOT clear them (it passes through resetBackupState
+  /// and the orchestrator needs both), so the reset belongs to runBackup,
+  /// the fresh entry point.
+  func testFreshRunBackup_ClearsPriorDuplicateDecisionState() throws {
+    // Fake (non-seam) paths: the spawned performQueueBasedBackup bails at its
+    // security-scope guard, so only runBackup's synchronous state setup runs
+    // (same pattern as BackupManagerReentryTests).
+    let manager = BackupManager(
+      diskSpaceChecker: MockDiskSpaceChecker(),
+      duplicateDetector: mockDuplicates,
+      backupAlertPresenter: MockBackupAlertPresenter(),
+      preferences: prefs
+    )
+    manager.setSource(URL(fileURLWithPath: "/Volumes/CardA/DCIM"))
+    manager.setDestination(URL(fileURLWithPath: "/Volumes/BackupDrive"), at: 0)
+    bm = manager
+
+    // Residue of a prior run's decision (non-default values throughout).
+    bm.state.duplicateAnalyses = [
+      destDir: DuplicateDetector.DuplicateAnalysis(
+        totalSourceFiles: 0,
+        exactDuplicates: [],
+        renamedDuplicates: [],
+        uniqueFiles: 0,
+        potentialSpaceSaved: 0,
+        destinationDriveUUID: nil
+      )
+    ]
+    bm.state.skipExactDuplicates = false
+    bm.state.skipRenamedDuplicates = true
+
+    bm.runBackup()
+
+    XCTAssertNil(
+      bm.state.duplicateAnalyses,
+      "a fresh run must not inherit the prior run's duplicate analyses")
+    XCTAssertTrue(
+      bm.state.skipExactDuplicates,
+      "a fresh run must restore the skip-exact default (true)")
+    XCTAssertFalse(
+      bm.state.skipRenamedDuplicates,
+      "a fresh run must restore the skip-renamed default (false)")
+  }
+
+  // MARK: - Defensive: continuation with no source
+
+  /// Should be unreachable (the dialog was armed by a run that had a source),
+  /// but a continuation finding no source must land in a clean idle state,
+  /// not silently strand the just-dismissed dialog.
+  func testDuplicateContinuationWithNoSource_LandsIdle() async throws {
+    let manager = BackupManager(
+      duplicateDetector: mockDuplicates,
+      backupAlertPresenter: MockBackupAlertPresenter(),
+      preferences: prefs
+    )
+    bm = manager  // no setSource — sourceURL is nil
+    bm.state.duplicateAnalyses = [
+      destDir: DuplicateDetector.DuplicateAnalysis(
+        totalSourceFiles: 0,
+        exactDuplicates: [],
+        renamedDuplicates: [],
+        uniqueFiles: 0,
+        potentialSpaceSaved: 0,
+        destinationDriveUUID: nil
+      )
+    ]
+
+    await bm.continueBackupAfterDuplicateDecision(skipExact: true, skipRenamed: false)
+
+    XCTAssertFalse(bm.state.isProcessing, "no-source continuation must land idle")
+    XCTAssertNil(bm.state.duplicateAnalyses, "stale analyses must not survive the dead end")
+    XCTAssertFalse(bm.showDuplicateWarning, "dialog must stay dismissed")
+  }
 }

--- a/ImageIntactUITests/DuplicateWarningUITests.swift
+++ b/ImageIntactUITests/DuplicateWarningUITests.swift
@@ -66,19 +66,14 @@ final class DuplicateWarningUITests: ImageIntactUITestCase {
     // INTENDED: the backup proceeds honoring the selection and the
     // completion stats report all 6 exact duplicates as skipped.
     //
-    // ACTUAL (gh#141): continueBackupAfterDuplicateDecision re-enters the
-    // preflight, which re-detects the same duplicates without consulting
-    // the just-made decision and re-presents the dialog forever; with
-    // detection enabled, Cancel is the only working exit. Verified
-    // 2026-06-12: the element dump at timeout shows sheet.duplicate present
-    // again. Once gh#141 is fixed, the stats assertions additionally
-    // require gh#142 (skipped counts never reach completion stats:
-    // recordFileSkipped has no production callers and filesSkipped is
-    // hard-coded to 0). This strict XCTExpectFailure fails loudly when
-    // BOTH are fixed — delete the wrapper then; the intended assertions
-    // below take over unchanged.
+    // The dialog loop (gh#141) is fixed — the backup now proceeds and the
+    // sheet does not re-present — but the stats assertions still require
+    // gh#142 (skipped counts never reach completion stats: recordFileSkipped
+    // has no production callers and filesSkipped is hard-coded to 0). This
+    // strict XCTExpectFailure fails loudly when gh#142 is fixed — delete the
+    // wrapper then; the intended assertions below take over unchanged.
     XCTExpectFailure(
-      "gh#141: Continue re-presents the dialog; gh#142: skip counts never reach stats"
+      "gh#142: skip counts never reach completion stats"
     ) {
       let completion = CompletionSheet(app: a)
       guard completion.marker.waitForExistence(timeout: 45) else {
@@ -106,25 +101,21 @@ final class DuplicateWarningUITests: ImageIntactUITestCase {
 
     duplicate.button("Copy All Anyway").click()
 
-    // INTENDED: the backup proceeds with no duplicate filtering and
-    // completes without failures. (The copied/skipped split is left to the
-    // gh#142 fix — copy-time skips of identical files are untallied today.)
-    //
-    // ACTUAL (gh#141): same continuation loop as Continue with Selection —
-    // the dialog re-presents forever and the backup never runs. Delete this
-    // wrapper when gh#141 is fixed.
-    XCTExpectFailure(
-      "gh#141: Copy All Anyway re-presents the dialog; backup never continues"
-    ) {
-      let completion = CompletionSheet(app: a)
-      guard completion.marker.waitForExistence(timeout: 45) else {
-        XCTFail("backup did not complete after Copy All Anyway")
-        return
-      }
-      let stats = pollValue(of: completion.marker, timeout: 10) { !$0.isEmpty }
-      XCTAssertTrue(stats.contains("failed=0"), "backup reported failures: \(stats)")
-      XCTAssertTrue(stats.contains("inSource=6"), "expected 6 source files in stats: \(stats)")
+    // The backup proceeds with no duplicate filtering and completes without
+    // failures (gh#141). The copied/skipped split is left to the gh#142 fix —
+    // copy-time skips of identical files are untallied today.
+    let completion = CompletionSheet(app: a)
+    guard completion.marker.waitForExistence(timeout: 45) else {
+      dumpElementTree(a, label: "duplicate-copyall-no-completion")
+      XCTFail("backup did not complete after Copy All Anyway; element tree dumped")
+      return
     }
+    XCTAssertTrue(
+      duplicate.marker.waitForNonExistence(timeout: 10),
+      "duplicate sheet still present after completion")
+    let stats = pollValue(of: completion.marker, timeout: 10) { !$0.isEmpty }
+    XCTAssertTrue(stats.contains("failed=0"), "backup reported failures: \(stats)")
+    XCTAssertTrue(stats.contains("inSource=6"), "expected 6 source files in stats: \(stats)")
   }
 
   func testCancelBackup_PerformsNoCopy() throws {

--- a/ImageIntactUITests/MigrationUITests.swift
+++ b/ImageIntactUITests/MigrationUITests.swift
@@ -105,29 +105,23 @@ final class MigrationUITests: ImageIntactUITestCase {
 
     migration.button("Skip").click()
 
-    // INTENDED: Skip declines the move but the backup still runs — files are
-    // copied into the organization folder, loose root files stay where they
-    // are, and the migration offer does not re-appear for this run.
-    //
-    // ACTUAL (gh#141): continueBackupAfterMigration re-enters the preflight,
-    // which re-detects the same loose root files (no decline-memory) and
-    // re-presents the dialog forever; the backup never runs. Verified
-    // 2026-06-12: the element dump at timeout shows sheet.migration present
-    // again. The strict XCTExpectFailure fails this test loudly the day
-    // gh#141 is fixed — delete the wrapper then; the intended assertions
-    // below take over unchanged.
-    XCTExpectFailure("gh#141: Skip re-presents the migration dialog; backup never continues") {
-      let completion = CompletionSheet(app: a)
-      guard completion.marker.waitForExistence(timeout: 45) else {
-        XCTFail("backup did not complete after Skip")
-        return
-      }
-      let stats = pollValue(of: completion.marker, timeout: 10) { !$0.isEmpty }
-      XCTAssertTrue(stats.contains("failed=0"), "backup reported failures: \(stats)")
-      XCTAssertTrue(stats.contains("inSource=6"), "expected 6 source files in stats: \(stats)")
-      XCTAssertTrue(
-        stats.contains("dest1:c6/s0/f0"),
-        "expected all 6 files copied fresh into the organization folder: \(stats)")
+    // Skip declines the move but the backup still runs — files are copied
+    // into the organization folder, loose root files stay where they are,
+    // and the migration offer does not re-appear for this run (gh#141).
+    let completion = CompletionSheet(app: a)
+    guard completion.marker.waitForExistence(timeout: 45) else {
+      dumpElementTree(a, label: "migration-skip-no-completion")
+      XCTFail("backup did not complete after Skip; element tree dumped")
+      return
     }
+    XCTAssertTrue(
+      migration.marker.waitForNonExistence(timeout: 10),
+      "migration sheet still present after completion")
+    let stats = pollValue(of: completion.marker, timeout: 10) { !$0.isEmpty }
+    XCTAssertTrue(stats.contains("failed=0"), "backup reported failures: \(stats)")
+    XCTAssertTrue(stats.contains("inSource=6"), "expected 6 source files in stats: \(stats)")
+    XCTAssertTrue(
+      stats.contains("dest1:c6/s0/f0"),
+      "expected all 6 files copied fresh into the organization folder: \(stats)")
   }
 }


### PR DESCRIPTION
Fixes #141 (board AMUX-391).

## Problem

Two of the three decision paths on the data-safety sheets never continued the backup — the dialog closed and immediately re-presented, forever:

- **Migration sheet "Skip"**: `continueBackupAfterMigration()` re-entered `performQueueBasedBackup()`, which re-ran `checkForMigration()`. The org folder is still absent after a decline and `BackupMigrationDetector` has no decline-memory, so the sheet re-armed every time. Only "Organize Files" escaped, and only as a side effect of creating the org folder.
- **Duplicate sheet "Continue with Selection" / "Copy All Anyway"**: `continueBackupAfterDuplicateDecision()` set the skip flags, then re-entered the preflight whose `checkForDuplicates()` never consulted them. With detection on, **Cancel was the only working exit** — backups with duplicates at the destination were impossible.

## Fix

Decision memory travels as parameters on the re-entry call, not as state:

- `performQueueBasedBackup(source:destinations:skipMigrationCheck:skipDuplicateCheck:)` — defaults false, so a fresh Run Backup re-offers both dialogs next run.
- `continueBackupAfterMigration()` re-enters with `skipMigrationCheck: true` (the duplicate check still runs — that dialog hasn't been shown yet at that point in the chain).
- `continueBackupAfterDuplicateDecision()` re-enters with **both** flags true (the duplicate sheet only appears after the migration question is resolved; re-running the migration check would re-present it in a migration-skip → duplicate chain).

Parameters over state flags: re-entry passes through `resetBackupState()`, so a state-based flag would need reset choreography that distinguishes fresh runs from continuations. Parameters scope the memory to the call chain by construction.

The flag edit pushed `BackupManagerQueueIntegration.swift` past the 500-line limit, so the preflight checks + continuations moved to `BackupManagerDecisionContinuation.swift` (same pattern as the AMUX-230 splits; the two check methods went `private` → internal for the cross-file call).

## Tests

- **New** `BackupManagerDecisionContinuationTests` (3 tests, red on unfixed code failing on exactly the loop assertions): migration Skip proceeds without re-presenting; duplicate Continue proceeds without re-analysis or re-presenting, and the copy result honors the selection end to end (mock analysis pins a real checksum); migration-skip → duplicate chain presents each dialog exactly once. Fixtures drive the real preflight via the `imageintact-uitest` marker-path seam; migration uses the real `BackupMigrationDetector`.
- **UI tests**: strict `XCTExpectFailure` wrappers deleted from `testSkipMigration_LeavesFilesInPlaceAndBackupCompletes` and `testCopyAllAnyway_ProceedsCopyingEverything` — their intended assertions now hold live. `testContinueWithSelection_SkipsExactDuplicates_StatsShowSkips` keeps its wrapper re-scoped to gh#142 only (skip counts still never reach completion stats).

## Verification

- Unit suite: 592 passed / 0 failed (2 known pre-existing flakes skipped per the standing recipe).
- `imageintact-ui-gate.sh fix/gh141-decision-loop`: **GREEN** (unit + UI phases) — the fixed Skip and Copy All Anyway paths verified in the live app.
- One gate run hit `CoreDataBatchTests.testBatchDeletePerformance` ("1 ≠ 0 sessions" after batch delete) — a fixed-sleep race against the shared `EventLogger` store; it passed in the same-code full-suite run before and the gate re-run after. Follow-up board task filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)