### PR TITLE
Isolate test UserDefaults to fix parallel flakes

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -165,7 +165,7 @@ class BackupManager {
         sourceManager.sourceURL = nil
         sourceManager.sourceFileTypes = [:]
         sourceManager.scanProgress = ""
-        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        BookmarkManager.clearBookmark(forKey: BookmarkManager.sourceKey)
         destinationManager.clearAll()
     }
 

--- a/ImageIntact/Models/BookmarkManager.swift
+++ b/ImageIntact/Models/BookmarkManager.swift
@@ -12,8 +12,8 @@ struct BookmarkManager {
 
     /// Backing store for bookmark persistence. Defaults to `.standard` (the
     /// shipping app's domain). Tests point this at a per-test
-    /// `UserDefaults(suiteName:)` via `IsolatedDefaultsTestCase`, so the suite is
-    /// hermetic and parallel-safe and a developer's real bookmarks are never
+    /// `UserDefaults(suiteName:)` via `IsolatedDefaultsTestCase`, so each test's
+    /// bookmark state is hermetic and a developer's real bookmarks are never
     /// touched. `nonisolated(unsafe)`: production only reads it; the sole writer
     /// is test setUp/tearDown on the main actor (and the test plan runs serially).
     nonisolated(unsafe) static var store: UserDefaults = .standard

--- a/ImageIntact/Models/BookmarkManager.swift
+++ b/ImageIntact/Models/BookmarkManager.swift
@@ -8,6 +8,16 @@ struct BookmarkManager {
     static let sourceKey = "sourceBookmark"
     static let destinationKeys = ["dest1Bookmark", "dest2Bookmark", "dest3Bookmark", "dest4Bookmark"]
 
+    // MARK: - Storage seam
+
+    /// Backing store for bookmark persistence. Defaults to `.standard` (the
+    /// shipping app's domain). Tests point this at a per-test
+    /// `UserDefaults(suiteName:)` via `IsolatedDefaultsTestCase`, so the suite is
+    /// hermetic and parallel-safe and a developer's real bookmarks are never
+    /// touched. `nonisolated(unsafe)`: production only reads it; the sole writer
+    /// is test setUp/tearDown on the main actor (and the test plan runs serially).
+    nonisolated(unsafe) static var store: UserDefaults = .standard
+
     // MARK: - Save
 
     static func saveBookmark(url: URL, key: String) {
@@ -23,7 +33,7 @@ struct BookmarkManager {
             let bookmark = try url.bookmarkData(
                 options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil
             )
-            UserDefaults.standard.set(bookmark, forKey: key)
+            store.set(bookmark, forKey: key)
             // UserDefaults auto-saves; synchronize() is a deprecated no-op
             logInfo("Successfully saved bookmark for \(key): \(url.lastPathComponent)")
         } catch {
@@ -34,7 +44,7 @@ struct BookmarkManager {
     // MARK: - Load
 
     static func loadBookmark(forKey key: String) -> URL? {
-        guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
+        guard let data = store.data(forKey: key) else { return nil }
         return loadBookmark(from: data, forKey: key)
     }
 
@@ -66,12 +76,21 @@ struct BookmarkManager {
                 includingResourceValuesForKeys: nil,
                 relativeTo: nil
             ) {
-                UserDefaults.standard.set(refreshed, forKey: key)
+                store.set(refreshed, forKey: key)
                 ApplicationLogger.shared.debug("Refreshed stale bookmark for \(key)", category: .fileSystem)
             }
         }
 
         return url
+    }
+
+    // MARK: - Clear
+
+    /// Removes a persisted bookmark from the backing store. Centralizes the
+    /// `removeObject(forKey:)` calls that were scattered across SourceManager /
+    /// DestinationManager so all bookmark persistence flows through `store`.
+    static func clearBookmark(forKey key: String) {
+        store.removeObject(forKey: key)
     }
 
     // MARK: - Create

--- a/ImageIntact/Models/DestinationManager.swift
+++ b/ImageIntact/Models/DestinationManager.swift
@@ -236,7 +236,7 @@ class DestinationManager {
         destinationItems[index] = DestinationItem(url: nil)
 
         if index < BookmarkManager.destinationKeys.count {
-            UserDefaults.standard.removeObject(forKey: BookmarkManager.destinationKeys[index])
+            BookmarkManager.clearBookmark(forKey: BookmarkManager.destinationKeys[index])
         }
     }
 
@@ -249,7 +249,7 @@ class DestinationManager {
             let oldID = destinationItems[0].id
             destinationDriveInfo.removeValue(forKey: oldID)
             destinationItems[0] = DestinationItem(url: nil)
-            UserDefaults.standard.removeObject(forKey: BookmarkManager.destinationKeys[0])
+            BookmarkManager.clearBookmark(forKey: BookmarkManager.destinationKeys[0])
             return
         }
 
@@ -266,14 +266,14 @@ class DestinationManager {
                 if let url = item.url {
                     BookmarkManager.saveBookmark(url: url, key: BookmarkManager.destinationKeys[i])
                 } else {
-                    UserDefaults.standard.removeObject(forKey: BookmarkManager.destinationKeys[i])
+                    BookmarkManager.clearBookmark(forKey: BookmarkManager.destinationKeys[i])
                 }
             }
         }
 
         // Clear trailing keys
         for i in destinationItems.count..<BookmarkManager.destinationKeys.count {
-            UserDefaults.standard.removeObject(forKey: BookmarkManager.destinationKeys[i])
+            BookmarkManager.clearBookmark(forKey: BookmarkManager.destinationKeys[i])
         }
 
         logInfo("Removed destination at index \(index), new count: \(destinationItems.count)")
@@ -404,7 +404,7 @@ class DestinationManager {
                         self.destinationDriveInfo.removeValue(forKey: itemID)
                         self.destinationItems[currentIndex] = DestinationItem(url: nil)
                         if currentIndex < BookmarkManager.destinationKeys.count {
-                            UserDefaults.standard.removeObject(forKey: BookmarkManager.destinationKeys[currentIndex])
+                            BookmarkManager.clearBookmark(forKey: BookmarkManager.destinationKeys[currentIndex])
                         }
                     }
                     return
@@ -443,7 +443,7 @@ class DestinationManager {
             destinationDriveInfo.removeValue(forKey: item.id)
         }
         for key in BookmarkManager.destinationKeys {
-            UserDefaults.standard.removeObject(forKey: key)
+            BookmarkManager.clearBookmark(forKey: key)
         }
         destinationItems = [DestinationItem(url: nil)]
     }

--- a/ImageIntact/Models/SourceManager.swift
+++ b/ImageIntact/Models/SourceManager.swift
@@ -81,7 +81,7 @@ class SourceManager {
             return savedSourceURL
         } else {
             logWarning("Saved source bookmark is invalid, clearing...")
-            UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+            BookmarkManager.clearBookmark(forKey: BookmarkManager.sourceKey)
             return nil
         }
     }
@@ -117,7 +117,7 @@ class SourceManager {
             // Clear the invalid bookmark
             if sourceURL == url {
                 sourceURL = nil
-                UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+                BookmarkManager.clearBookmark(forKey: BookmarkManager.sourceKey)
             }
             return
         }
@@ -279,7 +279,7 @@ class SourceManager {
             sourceURL = nil
             sourceFileTypes = [:]
             scanProgress = ""
-            UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+            BookmarkManager.clearBookmark(forKey: BookmarkManager.sourceKey)
 
             return "Moved \"\(name)\" to Trash"
         } catch {

--- a/ImageIntact/Views/SourceFolderSection.swift
+++ b/ImageIntact/Views/SourceFolderSection.swift
@@ -32,7 +32,7 @@ struct SourceFolderSection: View {
                         backupManager.sourceURL = nil
                         backupManager.sourceFileTypes = [:]
                         backupManager.scanProgress = ""
-                        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+                        BookmarkManager.clearBookmark(forKey: BookmarkManager.sourceKey)
                     },
                     onSelect: { _ in
                         // Already handled in backupManager.setSource()

--- a/ImageIntactTests/BackupManagerSetDestinationTests.swift
+++ b/ImageIntactTests/BackupManagerSetDestinationTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import ImageIntact
 
 @MainActor
-final class BackupManagerSetDestinationTests: XCTestCase {
+final class BackupManagerSetDestinationTests: IsolatedDefaultsTestCase {
 
     // MARK: - Helpers
 
@@ -25,12 +25,8 @@ final class BackupManagerSetDestinationTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-
-        // Clear bookmark state so init doesn't restore stale data.
-        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
-        for key in BookmarkManager.destinationKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
+        // Bookmark isolation handled by IsolatedDefaultsTestCase — store is a
+        // fresh suite; no manual removeObject needed.
 
         mockFileOps = MockFileOperations()
         mockPresenter = MockDestinationAlertPresenter()
@@ -45,11 +41,6 @@ final class BackupManagerSetDestinationTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
-        for key in BookmarkManager.destinationKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
-
         backupManager = nil
         mockPresenter = nil
         mockFileOps = nil

--- a/ImageIntactTests/BookmarkManagerStoreTests.swift
+++ b/ImageIntactTests/BookmarkManagerStoreTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import ImageIntact
+
+/// Verifies the injectable `BookmarkManager.store` seam: bookmark persistence
+/// goes through the injected `UserDefaults`, never `.standard`, when a test has
+/// pointed the seam at an isolated suite. This is what makes the bookmark tests
+/// parallel-safe and stops them from clobbering a developer's real bookmarks.
+@MainActor
+final class BookmarkManagerStoreTests: IsolatedDefaultsTestCase {
+
+    private let key = BookmarkManager.destinationKeys[0]   // "dest1Bookmark"
+
+    /// While a test is running, the seam points at the per-test suite.
+    func testStoreIsTheInjectedSuiteDuringTest() {
+        XCTAssertTrue(BookmarkManager.store === defaults,
+                      "BookmarkManager.store should be the per-test isolated suite")
+        XCTAssertFalse(BookmarkManager.store === UserDefaults.standard,
+                       "BookmarkManager.store must not be .standard during an isolated test")
+    }
+
+    /// saveBookmark writes into the injected suite and leaves `.standard` untouched.
+    func testSaveWritesToInjectedStoreNotStandard() throws {
+        let dir = try makeTempDir()
+        // Capture .standard BEFORE so we can prove it is unchanged regardless of
+        // whatever the developer's real defaults happen to hold for this key.
+        let standardBefore = UserDefaults.standard.data(forKey: key)
+
+        BookmarkManager.saveBookmark(url: dir, key: key)
+
+        XCTAssertNotNil(defaults.data(forKey: key),
+                        "bookmark should be written into the injected suite")
+        XCTAssertEqual(UserDefaults.standard.data(forKey: key), standardBefore,
+                       ".standard must be untouched by an isolated save")
+    }
+
+    /// loadBookmark reads back the bookmark written through the injected suite.
+    func testLoadReadsFromInjectedStore() throws {
+        let dir = try makeTempDir()
+        BookmarkManager.saveBookmark(url: dir, key: key)
+
+        let loaded = BookmarkManager.loadBookmark(forKey: key)
+        XCTAssertNotNil(loaded, "loadBookmark should resolve the bookmark from the injected suite")
+    }
+
+    /// loadDestinationBookmarks counts only what the injected suite holds.
+    func testLoadDestinationBookmarksReadsInjectedStore() throws {
+        let d1 = try makeTempDir()
+        let d2 = try makeTempDir()
+        BookmarkManager.saveBookmark(url: d1, key: BookmarkManager.destinationKeys[0])
+        BookmarkManager.saveBookmark(url: d2, key: BookmarkManager.destinationKeys[1])
+
+        let dests = BookmarkManager.loadDestinationBookmarks()
+        XCTAssertEqual(dests.count, 2, "should load exactly the two destinations saved to the suite")
+    }
+
+    /// clearBookmark removes the key from the injected suite.
+    func testClearBookmarkRemovesFromInjectedStore() throws {
+        let dir = try makeTempDir()
+        BookmarkManager.saveBookmark(url: dir, key: key)
+        XCTAssertNotNil(defaults.data(forKey: key))
+
+        BookmarkManager.clearBookmark(forKey: key)
+        XCTAssertNil(defaults.data(forKey: key), "clearBookmark should remove the key from the suite")
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BookmarkStoreTest_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+}

--- a/ImageIntactTests/DestinationManagerEstimateSessionTests.swift
+++ b/ImageIntactTests/DestinationManagerEstimateSessionTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// Tests for DestinationManager: getDestinationEstimate, session persistence, validation.
 @MainActor
-class DestinationManagerEstimateSessionTests: XCTestCase {
+class DestinationManagerEstimateSessionTests: IsolatedDefaultsTestCase {
 
     var mockFileOps: MockFileOperations!
     var mockDriveAnalyzer: MockDriveAnalyzer!
@@ -24,9 +24,8 @@ class DestinationManagerEstimateSessionTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        for key in BookmarkManager.destinationKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
+        // Bookmark keys are isolated per-test by IsolatedDefaultsTestCase.
+        // Non-bookmark preference keys are still on .standard — clean those up.
         UserDefaults.standard.removeObject(forKey: "TestDest1Path")
         UserDefaults.standard.removeObject(forKey: "TestDest2Path")
         sut = nil

--- a/ImageIntactTests/DestinationManagerMutationTests.swift
+++ b/ImageIntactTests/DestinationManagerMutationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// Tests for DestinationManager: clearDestination, removeDestination, clearAll.
 @MainActor
-class DestinationManagerMutationTests: XCTestCase {
+class DestinationManagerMutationTests: IsolatedDefaultsTestCase {
 
     var mockFileOps: MockFileOperations!
     var mockDriveAnalyzer: MockDriveAnalyzer!
@@ -24,9 +24,6 @@ class DestinationManagerMutationTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        for key in BookmarkManager.destinationKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
         sut = nil
         mockFileOps = nil
         mockDriveAnalyzer = nil
@@ -77,7 +74,7 @@ class DestinationManagerMutationTests: XCTestCase {
 
         sut.clearDestination(at: 0)
 
-        XCTAssertNil(UserDefaults.standard.data(forKey: BookmarkManager.destinationKeys[0]))
+        XCTAssertNil(defaults.data(forKey: BookmarkManager.destinationKeys[0]))
     }
 
     func testClearDestination_indexOutOfRange_noOp() {
@@ -151,7 +148,7 @@ class DestinationManagerMutationTests: XCTestCase {
 
         // 3 items -> 2 items. dest3Bookmark (index 2) should be cleared.
         XCTAssertNil(
-            UserDefaults.standard.data(forKey: BookmarkManager.destinationKeys[2]),
+            defaults.data(forKey: BookmarkManager.destinationKeys[2]),
             "Trailing bookmark key should be cleared after shift"
         )
     }
@@ -221,7 +218,7 @@ class DestinationManagerMutationTests: XCTestCase {
 
         for key in BookmarkManager.destinationKeys {
             XCTAssertNil(
-                UserDefaults.standard.data(forKey: key),
+                defaults.data(forKey: key),
                 "Bookmark key \(key) should be cleared"
             )
         }

--- a/ImageIntactTests/DestinationManagerTests.swift
+++ b/ImageIntactTests/DestinationManagerTests.swift
@@ -5,7 +5,7 @@ import XCTest
 /// Tests for DestinationManager: initialization, addDestination, and setDestination.
 /// See also: DestinationManagerMutationTests, DestinationManagerEstimateSessionTests.
 @MainActor
-class DestinationManagerTests: XCTestCase {
+class DestinationManagerTests: IsolatedDefaultsTestCase {
 
     var mockFileOps: MockFileOperations!
     var mockDriveAnalyzer: MockDriveAnalyzer!
@@ -25,9 +25,6 @@ class DestinationManagerTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        for key in BookmarkManager.destinationKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
         sut = nil
         mockFileOps = nil
         mockDriveAnalyzer = nil

--- a/ImageIntactTests/Helpers/.tdd-optional
+++ b/ImageIntactTests/Helpers/.tdd-optional
@@ -1,0 +1,3 @@
+Test-support base classes (BaseBackupManagerTestCase, IsolatedDefaultsTestCase).
+Exercised by the test classes that subclass them, not by standalone unit tests.
+Design-first still applies (see ../../.planning/design/Helpers.md).

--- a/ImageIntactTests/Helpers/BaseBackupManagerTestCase.swift
+++ b/ImageIntactTests/Helpers/BaseBackupManagerTestCase.swift
@@ -1,72 +1,44 @@
-// IMPORTANT: These tests mutate `UserDefaults.standard` and `PreferencesManager.shared`.
-// They are NOT parallel-safe. If parallel test execution is enabled in the
-// Xcode scheme, these tests will overwrite each other's state and fail
-// nondeterministically.
+// IMPORTANT: These tests mutate `PreferencesManager.shared`.
+// They are NOT parallel-safe for PreferencesManager state. If parallel test
+// execution is enabled in the Xcode scheme, pref mutations will overwrite each
+// other's state nondeterministically.
 //
-// Until `PreferencesManager` is refactored behind a protocol with per-test
-// in-memory storage (deferred follow-up), keep parallel execution disabled
-// in the Xcode test plan for `ImageIntactTests`.
+// Bookmark isolation is handled by IsolatedDefaultsTestCase (the base class).
+// Keep parallel execution disabled in the Xcode test plan for `ImageIntactTests`.
 
 import XCTest
 @testable import ImageIntact
 
-/// Shared base class for BackupManager test cases. Centralizes:
-/// - `BookmarkManager.sourceKey` / `destinationKeys` capture+restore (prevents
-///   the test suite from wiping a developer's saved bookmarks).
-/// - Cancellation of any in-flight backup before pref restoration (prevents
-///   orphaned Tasks if a test exits early or fails mid-flight).
+/// Shared base class for BackupManager test cases. Inherits per-test
+/// UserDefaults isolation from `IsolatedDefaultsTestCase` (bookmark keys are
+/// in a fresh suite for each test; `BookmarkManager.store` is pointed there
+/// automatically). Centralizes:
+/// - Cancellation of any in-flight backup before teardown (prevents orphaned
+///   Tasks if a test exits early or fails mid-flight).
 ///
 /// Per-test files are still responsible for capturing/restoring any
 /// `PreferencesManager.shared.X` values they specifically mutate (e.g.
-/// `showPreflightSummary`, `lastUsedOrganizationFolderName`). The base class
-/// just handles bookmarks because those are universal.
+/// `showPreflightSummary`, `lastUsedOrganizationFolderName`).
 ///
 /// Subclasses MUST set `bm` to the BackupManager under test in their setUp
 /// (after calling `super.setUp()`) so the teardown cancellation check works.
 @MainActor
-class BaseBackupManagerTestCase: XCTestCase {
+class BaseBackupManagerTestCase: IsolatedDefaultsTestCase {
     /// The BackupManager under test. Subclass setUp assigns this so the
     /// base tearDown can cancel any in-flight backup.
     var bm: BackupManager!
 
-    private var savedSourceBookmark: Any?
-    private var savedDestinationBookmarks: [String: Any] = [:]
-
     override func setUp() async throws {
         try await super.setUp()
-        // Capture bookmark state BEFORE clearing so we can restore in tearDown.
-        savedSourceBookmark = UserDefaults.standard.object(forKey: BookmarkManager.sourceKey)
-        savedDestinationBookmarks = [:]
-        for key in BookmarkManager.destinationKeys {
-            if let v = UserDefaults.standard.object(forKey: key) {
-                savedDestinationBookmarks[key] = v
-            }
-        }
-        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
-        for key in BookmarkManager.destinationKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
+        // Bookmark isolation is handled by IsolatedDefaultsTestCase.
+        // Subclasses add their own setup after this call.
     }
 
     override func tearDown() async throws {
-        // Cancel any in-flight backup before pref restoration, so spawned
+        // Cancel any in-flight backup before isolation teardown, so spawned
         // Tasks (e.g. `performQueueBasedBackup`) don't leak past this test.
         if bm?.state.isProcessing == true {
             bm.cancelOperation()
-        }
-
-        // Restore bookmarks. Conditional set-or-remove so absent keys stay absent.
-        if let v = savedSourceBookmark {
-            UserDefaults.standard.set(v, forKey: BookmarkManager.sourceKey)
-        } else {
-            UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
-        }
-        for key in BookmarkManager.destinationKeys {
-            if let v = savedDestinationBookmarks[key] {
-                UserDefaults.standard.set(v, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
-            }
         }
 
         // Release the BackupManager so its dependency graph deinits between

--- a/ImageIntactTests/Helpers/IsolatedDefaultsTestCase.swift
+++ b/ImageIntactTests/Helpers/IsolatedDefaultsTestCase.swift
@@ -12,6 +12,11 @@ import XCTest
 /// touched, and parallel XCTest worker processes never collide on the bookmark
 /// domain.
 ///
+/// NOTE: This isolates the bookmark domain only. The `Fast` test plan still runs
+/// serially (`parallelizable: false`) because `PreferencesManager`/`@AppStorage`
+/// state remains on `.standard` and is not yet isolated. Applying the same seam
+/// to preferences and re-enabling parallel execution is tracked as AMUX-456.
+///
 /// Subclasses MUST call `try await super.setUp()` / `try await super.tearDown()`.
 /// Bookmark-key reads/writes inside a test MUST use `defaults` (the injected
 /// suite), NOT `UserDefaults.standard`, so production `BookmarkManager` — which

--- a/ImageIntactTests/Helpers/IsolatedDefaultsTestCase.swift
+++ b/ImageIntactTests/Helpers/IsolatedDefaultsTestCase.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import ImageIntact
+
+/// Base class that isolates per-test `UserDefaults` so tests never share the
+/// on-disk `.standard` domain — the source of the parallel-execution bookmark
+/// races (see `.planning/design/test-defaults-isolation.md`).
+///
+/// Each test gets its own `UserDefaults(suiteName:)`. `BookmarkManager.store`
+/// (the production bookmark-persistence seam) is pointed at that suite for the
+/// duration of the test and reset to `.standard` in tearDown. The suite is then
+/// removed entirely. A developer's real saved bookmarks in `.standard` are never
+/// touched, and parallel XCTest worker processes never collide on the bookmark
+/// domain.
+///
+/// Subclasses MUST call `try await super.setUp()` / `try await super.tearDown()`.
+/// Bookmark-key reads/writes inside a test MUST use `defaults` (the injected
+/// suite), NOT `UserDefaults.standard`, so production `BookmarkManager` — which
+/// reads `BookmarkManager.store` — sees them.
+@MainActor
+class IsolatedDefaultsTestCase: XCTestCase {
+    /// The per-test isolated defaults. Equal to `BookmarkManager.store` for the
+    /// duration of the test.
+    private(set) var defaults: UserDefaults!
+
+    /// Suite name backing `defaults`; removed in tearDown.
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // UUID guarantees uniqueness even across parallel worker processes.
+        suiteName = "tech.tonalphoto.imageintact.test.\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: suiteName) else {
+            throw XCTSkip("Could not create isolated UserDefaults suite: \(suiteName ?? "<nil>")")
+        }
+        defaults = suite
+        BookmarkManager.store = suite
+    }
+
+    override func tearDown() async throws {
+        // Reset the production seam first so a failed removal can't leave a
+        // dead suite wired into BookmarkManager for the next test.
+        BookmarkManager.store = .standard
+        if let suiteName {
+            defaults?.removePersistentDomain(forName: suiteName)
+        }
+        defaults = nil
+        suiteName = nil
+        try await super.tearDown()
+    }
+}

--- a/ImageIntactTests/Helpers/IsolatedDefaultsTestCase.swift
+++ b/ImageIntactTests/Helpers/IsolatedDefaultsTestCase.swift
@@ -9,8 +9,9 @@ import XCTest
 /// (the production bookmark-persistence seam) is pointed at that suite for the
 /// duration of the test and reset to `.standard` in tearDown. The suite is then
 /// removed entirely. A developer's real saved bookmarks in `.standard` are never
-/// touched, and parallel XCTest worker processes never collide on the bookmark
-/// domain.
+/// touched. Isolating each test's bookmark state in its own suite is the
+/// prerequisite for parallel-safe execution of the bookmark tests (verified
+/// serially here; the parallel re-enable + verification is tracked in AMUX-456).
 ///
 /// NOTE: This isolates the bookmark domain only. The `Fast` test plan still runs
 /// serially (`parallelizable: false`) because `PreferencesManager`/`@AppStorage`

--- a/ImageIntactTests/ImageIntactTests.swift
+++ b/ImageIntactTests/ImageIntactTests.swift
@@ -9,31 +9,28 @@ import XCTest
 @testable import ImageIntact
 
 @MainActor
-class ImageIntactTests: XCTestCase {
-    
+class ImageIntactTests: IsolatedDefaultsTestCase {
+
     override class func setUp() {
         super.setUp()
         // Set environment variable for logging
         setenv("IDEPreferLogStreaming", "YES", 1)
     }
-    
-    override func setUp() {
-        super.setUp()
-        // Clear all saved bookmarks before each test
-        clearAllBookmarks()
-        
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Bookmark isolation is handled by IsolatedDefaultsTestCase.
+        // The inherited `defaults` suite is fresh and empty for each test.
+
         // Add a small delay to prevent timeout issues
         Thread.sleep(forTimeInterval: 0.1)
     }
-    
-    override func tearDown() {
-        // Clean up after tests
-        clearAllBookmarks()
-        
+
+    override func tearDown() async throws {
         // Clean up any test directories we created
         let fileManager = FileManager.default
         let tempDir = fileManager.temporaryDirectory
-        
+
         do {
             let contents = try fileManager.contentsOfDirectory(at: tempDir, includingPropertiesForKeys: nil)
             for item in contents {
@@ -56,18 +53,8 @@ class ImageIntactTests: XCTestCase {
         } catch {
             print("Failed to clean up test directories: \(error)")
         }
-        
-        super.tearDown()
-    }
-    
-    // MARK: - Helper Methods
-    
-    func clearAllBookmarks() {
-        UserDefaults.standard.removeObject(forKey: "sourceBookmark")
-        UserDefaults.standard.removeObject(forKey: "dest1Bookmark")
-        UserDefaults.standard.removeObject(forKey: "dest2Bookmark")
-        UserDefaults.standard.removeObject(forKey: "dest3Bookmark")
-        UserDefaults.standard.removeObject(forKey: "dest4Bookmark")
+
+        try await super.tearDown()
     }
     
     func createTestDirectory(name: String) -> URL? {
@@ -99,7 +86,7 @@ class ImageIntactTests: XCTestCase {
         
         // Save bookmark
         let bookmarkData = try testDir.bookmarkData(options: .withSecurityScope)
-        UserDefaults.standard.set(bookmarkData, forKey: "testBookmark")
+        defaults.set(bookmarkData, forKey: "testBookmark")
         
         // Load bookmark
         let loadedURL = BookmarkManager.loadBookmark(forKey: "testBookmark")
@@ -122,8 +109,8 @@ class ImageIntactTests: XCTestCase {
         // Save bookmarks
         let bookmark1 = try testDir1.bookmarkData(options: .withSecurityScope)
         let bookmark2 = try testDir2.bookmarkData(options: .withSecurityScope)
-        UserDefaults.standard.set(bookmark1, forKey: "dest1Bookmark")
-        UserDefaults.standard.set(bookmark2, forKey: "dest2Bookmark")
+        defaults.set(bookmark1, forKey: "dest1Bookmark")
+        defaults.set(bookmark2, forKey: "dest2Bookmark")
         
         // Load destinations
         let destinations = BookmarkManager.loadDestinationBookmarks()
@@ -141,8 +128,8 @@ class ImageIntactTests: XCTestCase {
         // Save bookmarks with a gap (no dest2Bookmark)
         let bookmark1 = try testDir1.bookmarkData(options: .withSecurityScope)
         let bookmark3 = try testDir3.bookmarkData(options: .withSecurityScope)
-        UserDefaults.standard.set(bookmark1, forKey: "dest1Bookmark")
-        UserDefaults.standard.set(bookmark3, forKey: "dest3Bookmark")
+        defaults.set(bookmark1, forKey: "dest1Bookmark")
+        defaults.set(bookmark3, forKey: "dest3Bookmark")
         
         // Load destinations - should only load first one
         let destinations = BookmarkManager.loadDestinationBookmarks()

--- a/ImageIntactTests/ImageIntactTests.swift
+++ b/ImageIntactTests/ImageIntactTests.swift
@@ -22,8 +22,9 @@ class ImageIntactTests: IsolatedDefaultsTestCase {
         // Bookmark isolation is handled by IsolatedDefaultsTestCase.
         // The inherited `defaults` suite is fresh and empty for each test.
 
-        // Add a small delay to prevent timeout issues
-        Thread.sleep(forTimeInterval: 0.1)
+        // Small delay to prevent timeout issues. setUp() is async on the
+        // @MainActor, so suspend cooperatively rather than blocking the thread.
+        try await Task.sleep(nanoseconds: 100_000_000) // 0.1s
     }
 
     override func tearDown() async throws {

--- a/ImageIntactTests/PreferencesProvidingTests.swift
+++ b/ImageIntactTests/PreferencesProvidingTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import ImageIntact
 
 @MainActor
-final class PreferencesProvidingTests: XCTestCase {
+final class PreferencesProvidingTests: IsolatedDefaultsTestCase {
 
     // MARK: - Protocol contract — read/write surface
 
@@ -235,13 +235,9 @@ final class PreferencesProvidingTests: XCTestCase {
     /// destinations". The test asserts the convergent outcome, which is the
     /// only externally observable shape without a destinationManager mock.
     func testBackupManager_init_restoreLastSession_false_initializesEmpty() {
-        // Clear any bookmark state from prior sessions (defensive — the test
-        // base classes also do this, but PreferencesProvidingTests is a
-        // plain XCTestCase).
-        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
-        for key in BookmarkManager.destinationKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
+        // Bookmark isolation is handled by IsolatedDefaultsTestCase — the
+        // inherited defaults suite is fresh and empty; BookmarkManager.store
+        // points there, so BackupManager.init sees no stale bookmarks.
         let prefs = InMemoryPreferencesProvider(restoreLastSession: false)
 
         let bm = BackupManager(

--- a/ImageIntactTests/SourceManagerTests.swift
+++ b/ImageIntactTests/SourceManagerTests.swift
@@ -15,20 +15,18 @@ import XCTest
 @testable import ImageIntact
 
 @MainActor
-final class SourceManagerTests: XCTestCase {
+final class SourceManagerTests: IsolatedDefaultsTestCase {
 
     // MARK: - Lifecycle
 
     override func setUp() async throws {
         try await super.setUp()
-        // Clear the source bookmark so loadFromSession tests start clean.
-        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
+        // Bookmark isolation handled by IsolatedDefaultsTestCase.
         // Reset file-type-filter preference to a known baseline.
         PreferencesManager.shared.resetToDefaults()
     }
 
     override func tearDown() async throws {
-        UserDefaults.standard.removeObject(forKey: BookmarkManager.sourceKey)
         PreferencesManager.shared.resetToDefaults()
         try await super.tearDown()
     }
@@ -136,7 +134,7 @@ final class SourceManagerTests: XCTestCase {
     /// BookmarkManager.sourceKey — the common "fresh launch" path.
     func testLoadFromSession_returnsNilWhenNoBookmark() {
         // setUp already clears the key; confirm baseline.
-        XCTAssertNil(UserDefaults.standard.data(forKey: BookmarkManager.sourceKey),
+        XCTAssertNil(defaults.data(forKey: BookmarkManager.sourceKey),
                      "Precondition: no bookmark data in UserDefaults")
         let manager = SourceManager(fileOperations: MockFileOperations())
         let result = manager.loadFromSession()
@@ -162,7 +160,7 @@ final class SourceManagerTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         BookmarkManager.saveBookmark(url: tempDir, key: BookmarkManager.sourceKey)
-        XCTAssertNotNil(UserDefaults.standard.data(forKey: BookmarkManager.sourceKey),
+        XCTAssertNotNil(defaults.data(forKey: BookmarkManager.sourceKey),
                         "Precondition: bookmark data must be present before calling loadFromSession")
 
         let manager = SourceManager(fileOperations: MockFileOperations())
@@ -172,7 +170,7 @@ final class SourceManagerTests: XCTestCase {
         // In a sandboxed runner where access succeeds, result is the URL (success path).
         // Either outcome is valid; we assert the invariant: if nil is returned the key is gone.
         if result == nil {
-            XCTAssertNil(UserDefaults.standard.data(forKey: BookmarkManager.sourceKey),
+            XCTAssertNil(defaults.data(forKey: BookmarkManager.sourceKey),
                          "When loadFromSession returns nil, it must clear the stale bookmark key")
             XCTAssertNil(manager.sourceURL,
                          "sourceURL must not be set when loadFromSession returns nil")

--- a/TestPlans/Fast.xctestplan
+++ b/TestPlans/Fast.xctestplan
@@ -43,7 +43,7 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:ImageIntact.xcodeproj",
         "identifier" : "ImageIntactTests",


### PR DESCRIPTION
## Problem

The `Fast` test plan ran `parallelizable: true` + random ordering while several test classes mutated the shared on-disk `UserDefaults` bookmark domain (`sourceBookmark`, `dest1Bookmark`..`dest4Bookmark`). Parallel XCTest worker *processes* raced on that one plist, so a **different** `UserDefaults`-backed test failed nondeterministically each run.

Observed this session on `origin/main` @ 9a9686e:
- isolated single test: **3/3 pass**
- parallel `Fast`: **1/3 green** (failures moved between `testLoadDestinationBookmarksWithSavedData`, `SourceManagerTests.testLoadFromSession_...`)
- serial `Fast`: **3/3 green**

The product code was always correct — only test isolation was broken. `parallelizable:true` was set optimistically in `417b333`; the later manager-extraction refactor invalidated it, which is why `BaseBackupManagerTestCase`'s header already documents "NOT parallel-safe... keep parallel disabled."

## Fix

- **`BookmarkManager.store`** — injectable `UserDefaults` (defaults to `.standard`). All bookmark reads/writes/clears in `BookmarkManager`, `SourceManager`, `DestinationManager`, `BackupManager.clearAllSelections`, and `SourceFolderSection` now flow through this single seam (new `clearBookmark(forKey:)` centralizes the previously-scattered removals).
- **`IsolatedDefaultsTestCase`** — points `BookmarkManager.store` at a unique per-test `UserDefaults(suiteName:)`, torn down after each test. Bookmark-touching test classes inherit it; a developer's real `.standard` bookmarks are never touched, and the bookmark domain is parallel-safe.
- **`Fast.xctestplan` → `parallelizable: false`** — the safety net for the state *not* isolated here (`PreferencesManager`/`@AppStorage`, hardwired to `.standard`, read by `SourceManager.init`). Restores the documented author intent. Full prefs isolation + re-enabling parallel is tracked as **AMUX-456**.

## Verification

- `BookmarkManagerStoreTests` (new): proves saves land in the injected suite, never `.standard`.
- Full `Fast` plan: **599 tests, 0 failures**, serial, repeated 3x clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)