### PR TITLE
Surface unreadable source files as failed (S4-11)

### DIFF
--- a/ImageIntact/Models/BackupManagerQueueIntegration.swift
+++ b/ImageIntact/Models/BackupManagerQueueIntegration.swift
@@ -80,6 +80,20 @@ extension BackupManager {
             return
         }
 
+        // Source files that couldn't be read (e.g. permission-denied) fail at
+        // manifest-build time and are excluded from preflightManifest. They
+        // reach no destination, so the copy phase never sees them — record them
+        // here so the completion report and stats surface them as failed
+        // instead of silently dropping the files (S4-11).
+        let sourceReadFailures = await manifestBuilder.buildFailures
+        for failure in sourceReadFailures
+        where !state.failedFiles.contains(where: {
+            $0.file == failure.file && $0.destination == "source"
+        }) {
+            state.failedFiles.append(
+                (file: failure.file, destination: "source", error: failure.error))
+        }
+
         ApplicationLogger.shared.debug("Preflight manifest built: \(preflightManifest.count) files", category: .backup)
         if preflightManifest.count > 0 {
             let totalBytes = preflightManifest.reduce(0) { $0 + $1.size }
@@ -259,7 +273,9 @@ extension BackupManager {
         }
 
         // Populate statistics and handle completion
-        populateStatistics(failures: failures, destinations: destinations)
+        populateStatistics(
+            failures: failures, sourceReadFailures: sourceReadFailures.count,
+            destinations: destinations)
         await handleBackupCompletion(destinations: destinations)
     }
 
@@ -315,17 +331,22 @@ extension BackupManager {
     @MainActor
     private func populateStatistics(
         failures: [(file: String, destination: String, error: String)],
+        sourceReadFailures: Int = 0,
         destinations _: [URL]
     ) {
         let totalFiles = progressTracker.totalFiles
         let processedFiles = progressTracker.processedFiles
-        let failedCount = failures.count
+        // Source-read failures were dropped from the manifest before the copy
+        // phase, so they're absent from both `failures` and `totalFiles`. Count
+        // them once toward the global failed + in-source totals so the sheet
+        // doesn't claim a smaller source that fully succeeded (S4-11).
+        let failedCount = failures.count + sourceReadFailures
 
         // Update overall stats from progress tracker
         // Use the actual manifest count for files processed, not the sum across destinations
         statistics.totalFilesProcessed = min(processedFiles, totalFiles)
         statistics.totalFilesFailed = failedCount
-        statistics.totalFilesInSource = totalFiles
+        statistics.totalFilesInSource = totalFiles + sourceReadFailures
 
         // Debug logging to diagnose the issue
         ApplicationLogger.shared.debug(
@@ -361,11 +382,14 @@ extension BackupManager {
                 sourceManager.sourceTotalBytes > 0
                     ? sourceManager.sourceTotalBytes
                     : (progressTracker.totalBytesCopied / Int64(max(1, destinationItems.count)))
+            // A source-read failure means the file reached no destination, so
+            // every destination is missing it — surface it in each dest's
+            // failed column too (global total already counts it once).
             statistics.destinationStats[destName] = DestinationStatistics(
                 destinationName: destName,
                 filesCopied: progress - destFailures,
                 filesSkipped: 0,
-                filesFailed: destFailures,
+                filesFailed: destFailures + sourceReadFailures,
                 bytesWritten: bytesPerDest,
                 timeElapsed: statistics.duration ?? 0,
                 averageSpeed: progressTracker.copySpeed

--- a/ImageIntact/Models/BackupManagerQueueIntegration.swift
+++ b/ImageIntact/Models/BackupManagerQueueIntegration.swift
@@ -62,14 +62,14 @@ extension BackupManager {
         }
 
         let manifestBuilder = ManifestBuilder()
-        let preflightManifest = await manifestBuilder.build(
+        let preflightResult = await manifestBuilder.buildReportingFailures(
             source: source,
             shouldCancel: { [weak self] in self?.state.shouldCancel ?? true },
             filter: fileTypeFilter,
             includeSubdirectories: includeSubdirectories
         )
 
-        guard let preflightManifest = preflightManifest else {
+        guard let preflightResult = preflightResult else {
             // Stop access before returning
             if preflightAccess {
                 source.stopAccessingSecurityScopedResource()
@@ -79,17 +79,16 @@ extension BackupManager {
             state.statusMessage = "Backup cancelled or failed"
             return
         }
+        let preflightManifest = preflightResult.entries
 
         // Source files that couldn't be read (e.g. permission-denied) fail at
-        // manifest-build time and are excluded from preflightManifest. They
-        // reach no destination, so the copy phase never sees them — record them
-        // here so the completion report and stats surface them as failed
-        // instead of silently dropping the files (S4-11).
-        let sourceReadFailures = await manifestBuilder.buildFailures
-        for failure in sourceReadFailures
-        where !state.failedFiles.contains(where: {
-            $0.file == failure.file && $0.destination == "source"
-        }) {
+        // manifest-build time and are excluded from the manifest. They reach no
+        // destination, so the copy phase never sees them — record them here so
+        // the completion report and stats surface them as failed instead of
+        // silently dropping the files (S4-11). This runs once per backup, so no
+        // dedup against state.failedFiles is needed.
+        let sourceReadFailures = preflightResult.failures
+        for failure in sourceReadFailures {
             state.failedFiles.append(
                 (file: failure.file, destination: "source", error: failure.error))
         }

--- a/ImageIntact/Models/ManifestBuilder.swift
+++ b/ImageIntact/Models/ManifestBuilder.swift
@@ -11,6 +11,13 @@ actor ManifestBuilder {
     /// Callback for failed files
     private var onFileError: ((String, String, String) -> Void)?
 
+    /// Files that failed checksum during the most recent `build` (e.g.
+    /// unreadable source files). Collected synchronously inside `build` so a
+    /// caller can read it deterministically after `await build(...)` — unlike
+    /// `onFileError`, which is dispatched asynchronously to the main actor and
+    /// may not have fired by the time `build` returns.
+    private(set) var buildFailures: [(file: String, error: String)] = []
+
     /// Batch processor for optimized file operations
     private let batchProcessor = BatchFileProcessor()
 
@@ -189,6 +196,10 @@ actor ManifestBuilder {
         filter: FileTypeFilter = FileTypeFilter(),
         includeSubdirectories: Bool = true
     ) async -> [FileManifestEntry]? {
+        // Reset per-build failure collection (fresh builder per backup in
+        // production; defensive for reused instances in tests).
+        buildFailures = []
+
         // Phase 1: Collect all files
         var filesToProcess: [(url: URL, relativePath: String, size: Int64)] = []
 
@@ -386,6 +397,7 @@ actor ManifestBuilder {
                     "No checksum for \(url.lastPathComponent): \(error.localizedDescription)",
                     category: .fileSystem
                 )
+                buildFailures.append((file: url.lastPathComponent, error: error.localizedDescription))
                 if let callback = onFileError {
                     Task { @MainActor in
                         callback(url.lastPathComponent, "manifest", error.localizedDescription)
@@ -401,6 +413,7 @@ actor ManifestBuilder {
                     "Missing checksum result for \(url.lastPathComponent) — BatchFileProcessor returned no entry for this URL despite no cancellation",
                     category: .fileSystem
                 )
+                buildFailures.append((file: url.lastPathComponent, error: "Missing checksum result"))
                 if let callback = onFileError {
                     Task { @MainActor in
                         callback(url.lastPathComponent, "manifest", "Missing checksum result")

--- a/ImageIntact/Models/ManifestBuilder.swift
+++ b/ImageIntact/Models/ManifestBuilder.swift
@@ -11,12 +11,15 @@ actor ManifestBuilder {
     /// Callback for failed files
     private var onFileError: ((String, String, String) -> Void)?
 
-    /// Files that failed checksum during the most recent `build` (e.g.
-    /// unreadable source files). Collected synchronously inside `build` so a
-    /// caller can read it deterministically after `await build(...)` — unlike
-    /// `onFileError`, which is dispatched asynchronously to the main actor and
-    /// may not have fired by the time `build` returns.
-    private(set) var buildFailures: [(file: String, error: String)] = []
+    /// Manifest entries plus the per-file failures (e.g. unreadable source
+    /// files) collected during the same build. Returned as a value so the
+    /// failures travel with the result — no shared instance state to corrupt
+    /// under actor re-entrancy, and deterministically available to the caller
+    /// (unlike `onFileError`, which is dispatched asynchronously to MainActor).
+    struct Result {
+        let entries: [FileManifestEntry]
+        let failures: [(file: String, error: String)]
+    }
 
     /// Batch processor for optimized file operations
     private let batchProcessor = BatchFileProcessor()
@@ -196,9 +199,24 @@ actor ManifestBuilder {
         filter: FileTypeFilter = FileTypeFilter(),
         includeSubdirectories: Bool = true
     ) async -> [FileManifestEntry]? {
-        // Reset per-build failure collection (fresh builder per backup in
-        // production; defensive for reused instances in tests).
-        buildFailures = []
+        await buildReportingFailures(
+            source: source, shouldCancel: shouldCancel, filter: filter,
+            includeSubdirectories: includeSubdirectories)?.entries
+    }
+
+    /// Build the manifest and also return the per-file failures collected during
+    /// the build (e.g. unreadable source files dropped from the manifest), so a
+    /// caller can surface them instead of silently losing the files.
+    func buildReportingFailures(
+        source: URL,
+        shouldCancel: @escaping () -> Bool,
+        filter: FileTypeFilter = FileTypeFilter(),
+        includeSubdirectories: Bool = true
+    ) async -> Result? {
+        // Per-build failure accumulator. Local (not instance state) so a
+        // concurrent call on the same actor instance cannot clobber this
+        // build's result across an await suspension.
+        var buildFailures: [(file: String, error: String)] = []
 
         // Phase 1: Collect all files
         var filesToProcess: [(url: URL, relativePath: String, size: Int64)] = []
@@ -423,7 +441,7 @@ actor ManifestBuilder {
         }
 
         ApplicationLogger.shared.debug("Manifest built with \(manifest.count) files", category: .fileSystem)
-        return manifest
+        return Result(entries: manifest, failures: buildFailures)
     }
 
     // MARK: - Private Methods

--- a/ImageIntact/Testing/UITestFixtures.swift
+++ b/ImageIntact/Testing/UITestFixtures.swift
@@ -210,9 +210,15 @@ enum UITestSeam {
     /// defensive so a leftover can never wedge the next regenerate or reset.
     private static func restorePermissions(at root: URL) {
       let fm = FileManager.default
-      guard let enumerator = fm.enumerator(at: root, includingPropertiesForKeys: nil)
+      guard
+        let enumerator = fm.enumerator(at: root, includingPropertiesForKeys: [.isSymbolicLinkKey])
       else { return }
       for case let url as URL in enumerator {
+        // Skip symlinks: setAttributes(ofItemAtPath:) resolves them, so a
+        // symlink planted in the fixture tree could chmod a file outside it.
+        if (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink == true {
+          continue
+        }
         try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
       }
     }

--- a/ImageIntact/Testing/UITestFixtures.swift
+++ b/ImageIntact/Testing/UITestFixtures.swift
@@ -58,6 +58,10 @@ enum UITestSeam {
       var sourceCount: Int
       var destCount: Int
       var prefill: Prefill
+      /// Number of source files to make unreadable (chmod 000) so the backup
+      /// hits real per-file read failures. Defaulted so existing positional
+      /// call sites and the synthesized memberwise init keep compiling.
+      var failureCount: Int = 0
     }
 
     enum Prefill: String {
@@ -103,11 +107,12 @@ enum UITestSeam {
 
     // MARK: - Spec parsing
 
-    /// Grammar: `src=<1...999>[,dests=<1...8>][,prefill=none|exact|loose]`
+    /// Grammar: `src=<1...999>[,dests=<1...8>][,prefill=none|exact|loose][,failures=<0...src>]`
     static func parseSpec(_ raw: String) -> Spec? {
       var sourceCount: Int?
       var destCount = 1
       var prefill = Prefill.none
+      var failureCount = 0
 
       for field in raw.split(separator: ",") {
         let pair = field.split(separator: "=", maxSplits: 1)
@@ -123,12 +128,20 @@ enum UITestSeam {
         case "prefill":
           guard let p = Prefill(rawValue: value) else { return nil }
           prefill = p
+        case "failures":
+          guard let n = Int(value), (0...999).contains(n) else { return nil }
+          failureCount = n
         default:
           return nil
         }
       }
       guard let sourceCount else { return nil }
-      return Spec(sourceCount: sourceCount, destCount: destCount, prefill: prefill)
+      // Can't fail more files than exist (validated here, where src is known
+      // regardless of field order).
+      guard (0...sourceCount).contains(failureCount) else { return nil }
+      return Spec(
+        sourceCount: sourceCount, destCount: destCount, prefill: prefill,
+        failureCount: failureCount)
     }
 
     // MARK: - Generation
@@ -141,7 +154,10 @@ enum UITestSeam {
       guard isUITestPath(dir) else { throw SeamError.unmarkedPath(dir.path) }
 
       let fm = FileManager.default
-      if fm.fileExists(atPath: dir.path) { try fm.removeItem(at: dir) }
+      if fm.fileExists(atPath: dir.path) {
+        restorePermissions(at: dir)
+        try fm.removeItem(at: dir)
+      }
 
       let source = dir.appendingPathComponent("source")
       try fm.createDirectory(at: source, withIntermediateDirectories: true)
@@ -175,7 +191,30 @@ enum UITestSeam {
         }
         dests.append(dest)
       }
+
+      // Make the first `failureCount` source files unreadable. Done AFTER the
+      // prefill copies above so those copies are made from readable originals;
+      // only the source the backup reads is poisoned. The owner (non-root test
+      // runner) gets EACCES on open() for read, a genuine per-file failure.
+      if spec.failureCount > 0 {
+        for file in sourceFiles.prefix(spec.failureCount) {
+          try fm.setAttributes([.posixPermissions: 0], ofItemAtPath: file.path)
+        }
+      }
       return GeneratedPaths(source: source, dests: dests)
+    }
+
+    /// Reset traversable permissions across a fixture tree before deletion.
+    /// `failures=N` leaves mode-000 files behind; POSIX still lets the owner
+    /// unlink a 000 *file* (deletion is a parent-dir operation), but be
+    /// defensive so a leftover can never wedge the next regenerate or reset.
+    private static func restorePermissions(at root: URL) {
+      let fm = FileManager.default
+      guard let enumerator = fm.enumerator(at: root, includingPropertiesForKeys: nil)
+      else { return }
+      for case let url as URL in enumerator {
+        try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+      }
     }
 
     private static func writeJPEG(to url: URL, hue: CGFloat, exifDate: String) throws {
@@ -281,6 +320,7 @@ enum UITestSeam {
     static func reset(defaults: UserDefaults, domainName: String, fixturesRoot: URL) {
       defaults.removePersistentDomain(forName: domainName)
       if isUITestPath(fixturesRoot) {
+        restorePermissions(at: fixturesRoot)
         try? FileManager.default.removeItem(at: fixturesRoot)
       }
     }

--- a/ImageIntactTests/ManifestBuilderFailureTests.swift
+++ b/ImageIntactTests/ManifestBuilderFailureTests.swift
@@ -1,0 +1,66 @@
+//
+//  ManifestBuilderFailureTests.swift
+//  ImageIntactTests
+//
+//  An unreadable source file must be reported in `buildFailures` and excluded
+//  from the manifest — so the backup pipeline can surface it as failed>0
+//  instead of silently dropping it. AMUX-375 / S4-11.
+//
+
+import XCTest
+
+@testable import ImageIntact
+
+@MainActor
+final class ManifestBuilderFailureTests: XCTestCase {
+  var testDirectory: URL!
+  var manifestBuilder: ManifestBuilder!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ManifestFailureTests_\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: testDirectory, withIntermediateDirectories: true)
+    manifestBuilder = ManifestBuilder()
+  }
+
+  override func tearDown() async throws {
+    if FileManager.default.fileExists(atPath: testDirectory.path) {
+      // Restore perms so the 000 fixture file can be removed.
+      if let en = FileManager.default.enumerator(at: testDirectory, includingPropertiesForKeys: nil)
+      {
+        for case let url as URL in en {
+          try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o644], ofItemAtPath: url.path)
+        }
+      }
+      try FileManager.default.removeItem(at: testDirectory)
+    }
+    try await super.tearDown()
+  }
+
+  func testBuild_reportsUnreadableSourceFileAndExcludesItFromManifest() async throws {
+    try Data("readable".utf8).write(to: testDirectory.appendingPathComponent("ok.jpg"))
+    let locked = testDirectory.appendingPathComponent("locked.jpg")
+    try Data("nope".utf8).write(to: locked)
+    try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: locked.path)
+
+    let manifest = await manifestBuilder.build(source: testDirectory, shouldCancel: { false })
+    let failures = await manifestBuilder.buildFailures
+
+    let names = (manifest ?? []).map { URL(fileURLWithPath: $0.relativePath).lastPathComponent }
+    XCTAssertEqual(names, ["ok.jpg"], "unreadable file must be excluded from the manifest")
+    XCTAssertEqual(failures.map(\.file), ["locked.jpg"], "unreadable file must be in buildFailures")
+  }
+
+  func testBuild_noFailures_leavesBuildFailuresEmpty() async throws {
+    try Data("a".utf8).write(to: testDirectory.appendingPathComponent("a.jpg"))
+    try Data("b".utf8).write(to: testDirectory.appendingPathComponent("b.jpg"))
+
+    let manifest = await manifestBuilder.build(source: testDirectory, shouldCancel: { false })
+    let failures = await manifestBuilder.buildFailures
+
+    XCTAssertEqual(manifest?.count, 2)
+    XCTAssertTrue(failures.isEmpty, "a clean build must report no failures")
+  }
+}

--- a/ImageIntactTests/ManifestBuilderFailureTests.swift
+++ b/ImageIntactTests/ManifestBuilderFailureTests.swift
@@ -2,9 +2,9 @@
 //  ManifestBuilderFailureTests.swift
 //  ImageIntactTests
 //
-//  An unreadable source file must be reported in `buildFailures` and excluded
-//  from the manifest — so the backup pipeline can surface it as failed>0
-//  instead of silently dropping it. AMUX-375 / S4-11.
+//  An unreadable source file must be reported in the build result's failures
+//  and excluded from the manifest — so the backup pipeline can surface it as
+//  failed>0 instead of silently dropping it. AMUX-375 / S4-11.
 //
 
 import XCTest
@@ -45,22 +45,25 @@ final class ManifestBuilderFailureTests: XCTestCase {
     try Data("nope".utf8).write(to: locked)
     try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: locked.path)
 
-    let manifest = await manifestBuilder.build(source: testDirectory, shouldCancel: { false })
-    let failures = await manifestBuilder.buildFailures
+    let result = await manifestBuilder.buildReportingFailures(
+      source: testDirectory, shouldCancel: { false })
 
-    let names = (manifest ?? []).map { URL(fileURLWithPath: $0.relativePath).lastPathComponent }
+    let names = (result?.entries ?? []).map {
+      URL(fileURLWithPath: $0.relativePath).lastPathComponent
+    }
     XCTAssertEqual(names, ["ok.jpg"], "unreadable file must be excluded from the manifest")
-    XCTAssertEqual(failures.map(\.file), ["locked.jpg"], "unreadable file must be in buildFailures")
+    XCTAssertEqual(
+      result?.failures.map(\.file), ["locked.jpg"], "unreadable file must be reported in failures")
   }
 
   func testBuild_noFailures_leavesBuildFailuresEmpty() async throws {
     try Data("a".utf8).write(to: testDirectory.appendingPathComponent("a.jpg"))
     try Data("b".utf8).write(to: testDirectory.appendingPathComponent("b.jpg"))
 
-    let manifest = await manifestBuilder.build(source: testDirectory, shouldCancel: { false })
-    let failures = await manifestBuilder.buildFailures
+    let result = await manifestBuilder.buildReportingFailures(
+      source: testDirectory, shouldCancel: { false })
 
-    XCTAssertEqual(manifest?.count, 2)
-    XCTAssertTrue(failures.isEmpty, "a clean build must report no failures")
+    XCTAssertEqual(result?.entries.count, 2)
+    XCTAssertEqual(result?.failures.isEmpty, true, "a clean build must report no failures")
   }
 }

--- a/ImageIntactTests/UITestFixturesTests.swift
+++ b/ImageIntactTests/UITestFixturesTests.swift
@@ -211,4 +211,100 @@ final class UITestFixturesTests: XCTestCase {
       FileManager.default.fileExists(atPath: unmarked.path),
       "reset must never delete a directory that lacks the imageintact-uitest marker")
   }
+
+  // MARK: - Failure injection (failures=N)
+
+  func testParseSpec_parsesFailuresField() {
+    let spec = UITestFixtures.parseSpec("src=6,failures=2")
+    XCTAssertEqual(
+      spec, UITestFixtures.Spec(sourceCount: 6, destCount: 1, prefill: .none, failureCount: 2))
+  }
+
+  func testParseSpec_failuresDefaultsToZero() {
+    XCTAssertEqual(UITestFixtures.parseSpec("src=3")?.failureCount, 0)
+  }
+
+  func testParseSpec_rejectsFailuresExceedingSource() {
+    XCTAssertNil(UITestFixtures.parseSpec("src=2,failures=3"))
+  }
+
+  func testParseSpec_rejectsGarbageFailures() {
+    XCTAssertNil(UITestFixtures.parseSpec("src=6,failures=-1"))
+    XCTAssertNil(UITestFixtures.parseSpec("src=6,failures=two"))
+  }
+
+  func testGenerate_failuresMakesFirstNSourceFilesUnreadable() throws {
+    let paths = try UITestFixtures.generate(
+      into: markedRoot, spec: .init(sourceCount: 4, destCount: 1, prefill: .none, failureCount: 2))
+    let sources = try FileManager.default.contentsOfDirectory(
+      at: paths.source, includingPropertiesForKeys: nil)
+      .filter { $0.pathExtension == "jpg" }
+      .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    XCTAssertEqual(sources.count, 4)
+    // fix-01, fix-02 unreadable; the rest readable.
+    for file in sources.prefix(2) {
+      let mode =
+        try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions] as? Int
+      XCTAssertEqual(mode, 0, "\(file.lastPathComponent) should be mode 000")
+      XCTAssertFalse(
+        FileManager.default.isReadableFile(atPath: file.path),
+        "\(file.lastPathComponent) should not be readable")
+    }
+    for file in sources.dropFirst(2) {
+      XCTAssertTrue(
+        FileManager.default.isReadableFile(atPath: file.path),
+        "\(file.lastPathComponent) should remain readable")
+    }
+    // Restore so tearDown's removeItem is unhindered even if FileManager balks.
+    for file in sources.prefix(2) {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
+    }
+  }
+
+  func testGenerate_prefillCopiesStayReadableWhenFailuresSet() throws {
+    // Prefill copies are made BEFORE the source chmod, so they must be intact.
+    let paths = try UITestFixtures.generate(
+      into: markedRoot,
+      spec: .init(sourceCount: 3, destCount: 1, prefill: .exact, failureCount: 1),
+      organizationName: "Org")
+    let seeded = try FileManager.default.contentsOfDirectory(
+      at: paths.dests[0].appendingPathComponent("Org"), includingPropertiesForKeys: nil)
+      .filter { $0.pathExtension == "jpg" }
+    XCTAssertEqual(seeded.count, 3)
+    for file in seeded {
+      XCTAssertTrue(
+        FileManager.default.isReadableFile(atPath: file.path),
+        "prefill copy \(file.lastPathComponent) must be readable")
+    }
+    // Restore source perms for clean teardown.
+    let sources = try FileManager.default.contentsOfDirectory(
+      at: paths.source, includingPropertiesForKeys: nil)
+    for file in sources {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
+    }
+  }
+
+  func testGenerate_regeneratesOverTreeWithUnreadableFiles() throws {
+    _ = try UITestFixtures.generate(
+      into: markedRoot, spec: .init(sourceCount: 3, destCount: 1, prefill: .none, failureCount: 2))
+    // Second generate must not throw despite the prior tree holding 000 files.
+    let paths = try UITestFixtures.generate(
+      into: markedRoot, spec: .init(sourceCount: 2, destCount: 1, prefill: .none))
+    let sources = try FileManager.default.contentsOfDirectory(
+      at: paths.source, includingPropertiesForKeys: nil)
+      .filter { $0.pathExtension == "jpg" }
+    XCTAssertEqual(sources.count, 2)
+    for file in sources {
+      XCTAssertTrue(FileManager.default.isReadableFile(atPath: file.path))
+    }
+  }
+
+  func testReset_deletesTreeContainingUnreadableFiles() throws {
+    _ = try UITestFixtures.generate(
+      into: markedRoot, spec: .init(sourceCount: 3, destCount: 1, prefill: .none, failureCount: 2))
+    UITestFixtures.reset(defaults: defaults, domainName: suiteName, fixturesRoot: markedRoot)
+    XCTAssertFalse(
+      FileManager.default.fileExists(atPath: markedRoot.path),
+      "reset must delete the tree even when it contains mode-000 files")
+  }
 }

--- a/ImageIntactUITests/FailurePathUITests.swift
+++ b/ImageIntactUITests/FailurePathUITests.swift
@@ -1,0 +1,54 @@
+//
+//  FailurePathUITests.swift
+//  ImageIntactUITests
+//
+//  P0 integrity: a backup with unreadable source files must surface the
+//  failures honestly (failed>0) and still copy the readable ones — never
+//  silently succeed with failed=0. AMUX-375.
+//
+
+import XCTest
+
+final class FailurePathUITests: ImageIntactUITestCase {
+
+  func testBackup_WithUnreadableSourceFiles_SurfacesFailedCount() throws {
+    // 6 source files; 2 are chmod-000 (unreadable). The completion sheet must
+    // report the 2 as failed and still copy the other 4.
+    let a = launchApp(fixtures: "src=6,dests=1,failures=2")
+    let main = MainScreen(app: a)
+
+    if !main.folderRow("source").waitForExistence(timeout: 10) {
+      dumpElementTree(a, label: "failure-path-no-source-row")
+      XCTFail("seam-selected source folder is not shown in the UI; element tree dumped")
+      return
+    }
+    XCTAssertTrue(main.folderRow("dest1").exists, "seam-selected destination is not shown")
+
+    XCTAssertTrue(waitUntilHittable(main.runBackupButton), "Run Backup never became clickable")
+    main.runBackupButton.click()
+
+    let completion = CompletionSheet(app: a)
+    if !completion.marker.waitForExistence(timeout: 120) {
+      dumpElementTree(a, label: "failure-path-no-completion")
+      XCTFail("completion sheet never appeared; element tree dumped")
+      return
+    }
+
+    let stats = pollValue(of: completion.marker, timeout: 10) { !$0.isEmpty }
+    XCTAssertFalse(stats.isEmpty, "completion stats accessibility value is empty")
+
+    // Integrity: the 2 unreadable files must be reported, not silently dropped.
+    XCTAssertFalse(
+      stats.contains("failed=0"),
+      "backup silently succeeded despite 2 unreadable source files: \(stats)")
+    XCTAssertTrue(
+      stats.contains("failed=2"),
+      "expected exactly 2 reported failures: \(stats)")
+    XCTAssertTrue(
+      stats.contains("inSource=6"),
+      "expected all 6 source files accounted for: \(stats)")
+    XCTAssertTrue(
+      stats.contains("dest1:c4"),
+      "expected the 4 readable files to still copy to dest1: \(stats)")
+  }
+}

--- a/ImageIntactUITests/FailurePathUITests.swift
+++ b/ImageIntactUITests/FailurePathUITests.swift
@@ -48,7 +48,7 @@ final class FailurePathUITests: ImageIntactUITestCase {
       stats.contains("inSource=6"),
       "expected all 6 source files accounted for: \(stats)")
     XCTAssertTrue(
-      stats.contains("dest1:c4"),
-      "expected the 4 readable files to still copy to dest1: \(stats)")
+      stats.contains("dest1:c4/s0/f2"),
+      "expected dest1 to copy the 4 readable files and report the 2 unreadable as failed: \(stats)")
   }
 }


### PR DESCRIPTION
## What

A backup whose source folder contains unreadable files now reports those files
as failed instead of silently dropping them.

## The bug (found by the new test)

While adding failure-path UI coverage (AMUX-375), the test surfaced a real
integrity bug (filed as S4-11). For a 6-file source with 2 unreadable files,
the completion sheet showed:

```
processed=4;skipped=0;failed=0;inSource=4;dests=dest1:c4/s0/f0
```

Green "Backup Complete" header, `failed=0`, and `inSource` undercounted to 4.
The 2 unreadable files were invisible: not failed, not skipped, not even counted
in the source. A user would be told the backup fully succeeded while 2 of their
files were never copied. Same class of issue as the gh#134 verify-cache fix:
the SHA-256 receipt only attested the files that happened to be readable.

Root cause: unreadable files fail at manifest-build time (`batchCalculateChecksums`
returns `.failure`) and are dropped from the manifest. The preflight manifest
build (`BackupManagerQueueIntegration`) passed no error callback, so those
failures were logged and discarded; the copy phase then ran on the surviving
manifest with zero failures.

## The fix

- `ManifestBuilder` collects per-build checksum failures synchronously into
  `buildFailures` (the existing `onFileError` is dispatched async to the main
  actor, so it isn't reliably readable right after `await build`).
- `performQueueBasedBackup` reads `buildFailures` after the preflight build,
  records each as a `(file, "source", error)` entry, and threads the count into
  `populateStatistics`.
- `populateStatistics` adds the count to the global `failed` + `inSource` totals
  and to each destination's `failed` column (a source-read failure reached no
  destination, so every destination is missing it).

After the fix, the same scenario reports honestly:

```
processed=4;skipped=0;failed=2;inSource=6;dests=dest1:c4/s0/f2
```

Clean backups are unaffected (the added term is 0), so existing assertions like
`dest1:c6/s0/f0` stay green.

## Test coverage

- `failures=N` option added to the `--testAutoFixtures` UI-test seam (chmod-000s
  the first N source files; permissions restored before the fixture tree is
  deleted). 7 new unit tests in `UITestFixturesTests`.
- `ManifestBuilderFailureTests`: unreadable file lands in `buildFailures` and is
  excluded from the manifest; clean build reports none.
- `FailurePathUITests`: end-to-end assertion of `failed=2;inSource=6;dest1:c4/s0/f2`.
- Full UI gate (unit + UI) GREEN on cc33d15.

## Review note

This changes core backup-integrity behavior, so it is up to Konrad to merge.
Product decision taken: count unreadable source as failed and proceed
(non-blocking); a preflight "N files unreadable, continue?" warning was
considered and deferred as a possible follow-up.

Closes AMUX-375. Fixes S4-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
