### PR TITLE
Add powerbox open-panel UI test with runner byte verification

### DIFF
--- a/ImageIntactUITests/FixtureFactory.swift
+++ b/ImageIntactUITests/FixtureFactory.swift
@@ -33,11 +33,16 @@ enum FixtureFactory {
         case unmarkedPath(String)
     }
 
-    /// True if `url` (or its immediate parent) is name-marked as ours. The
-    /// parent case covers the nested layout the test builds:
-    /// `<...imageintact-uitest-powerbox-UUID>/source`.
+    /// True if `url` is inside the process temporary directory AND `url` (or its
+    /// immediate parent) is name-marked as ours. The parent case covers the
+    /// nested layout the test builds: `<...imageintact-uitest-powerbox-UUID>/source`.
+    /// The temp-directory requirement is defense in depth for the
+    /// delete-then-regenerate contract: a real user folder whose name merely
+    /// contains the marker substring must never be eligible for deletion.
     static func isFixturePath(_ url: URL) -> Bool {
         let dir = url.standardizedFileURL
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).standardizedFileURL
+        guard dir.path == tmp.path || dir.path.hasPrefix(tmp.path + "/") else { return false }
         return dir.lastPathComponent.contains(pathMarker)
             || dir.deletingLastPathComponent().lastPathComponent.contains(pathMarker)
     }

--- a/ImageIntactUITests/FixtureFactory.swift
+++ b/ImageIntactUITests/FixtureFactory.swift
@@ -54,12 +54,14 @@ enum FixtureFactory {
         let fm = FileManager.default
         if fm.fileExists(atPath: target.path) { try fm.removeItem(at: target) }
         try fm.createDirectory(at: target, withIntermediateDirectories: true)
-        return try (1...count).map { i in
-            let url = target.appendingPathComponent(String(format: "fix-%02d.jpg", i))
+        // Half-open range so count == 0 yields an empty dir instead of a fatal
+        // 1...0 range error.
+        return try (0..<count).map { i in
+            let url = target.appendingPathComponent(String(format: "fix-%02d.jpg", i + 1))
             try writeJPEG(
                 to: url,
-                hue: CGFloat(i - 1) / CGFloat(count),
-                exifDate: String(format: "2026:01:01 12:%02d:00", min(i, 59)))
+                hue: CGFloat(i) / CGFloat(count),
+                exifDate: String(format: "2026:01:01 12:%02d:00", min(i + 1, 59)))
             return url
         }
     }

--- a/ImageIntactUITests/FixtureFactory.swift
+++ b/ImageIntactUITests/FixtureFactory.swift
@@ -1,0 +1,95 @@
+//
+//  FixtureFactory.swift
+//  ImageIntactUITests
+//
+//  Runner-side fixture generation for the powerbox open-panel test. The UI
+//  test runner is sandboxed for real and cannot reach the app's container, so
+//  fixtures the app must read through a genuine NSOpenPanel grant have to live
+//  in the RUNNER's own container. This generates them there; the app reaches
+//  them through the powerbox selection (security-scoped bookmark), exactly as a
+//  user picking a folder would. Because both the source tree and the copied
+//  destination then live in the runner's container, the runner can recompute
+//  checksums and byte-verify the result - ground truth the app's own stats
+//  cannot provide. Ported from Palomino's FixtureFactory.
+//
+//  This file is a member of the UI test target only (never shipped), so it is
+//  not #if DEBUG-gated. The app generates its own in-container fixtures through
+//  ImageIntact/Testing/UITestFixtures.swift.
+//
+
+import AppKit
+import CryptoKit
+import ImageIO
+import UniformTypeIdentifiers
+
+enum FixtureFactory {
+    /// Name marker required on (or immediately above) any directory this factory
+    /// deletes or regenerates. The delete-then-regenerate contract is a loaded
+    /// gun if it ever points at a real user directory; refuse anything that is
+    /// not explicitly ours.
+    static let pathMarker = "imageintact-uitest"
+
+    enum FactoryError: Error {
+        case unmarkedPath(String)
+    }
+
+    /// True if `url` (or its immediate parent) is name-marked as ours. The
+    /// parent case covers the nested layout the test builds:
+    /// `<...imageintact-uitest-powerbox-UUID>/source`.
+    static func isFixturePath(_ url: URL) -> Bool {
+        let dir = url.standardizedFileURL
+        return dir.lastPathComponent.contains(pathMarker)
+            || dir.deletingLastPathComponent().lastPathComponent.contains(pathMarker)
+    }
+
+    /// Generates `count` deterministic JPEGs (fix-01.jpg, fix-02.jpg, ...) into
+    /// `dir`. `dir` must be name-marked (itself or its parent); it is removed
+    /// and recreated. Each file gets a distinct hue so the files have distinct
+    /// bytes, which makes the checksum match meaningful. Returns the generated
+    /// URLs in order.
+    @discardableResult
+    static func generateImages(into dir: URL, count: Int) throws -> [URL] {
+        let target = dir.standardizedFileURL
+        guard isFixturePath(target) else { throw FactoryError.unmarkedPath(target.path) }
+        let fm = FileManager.default
+        if fm.fileExists(atPath: target.path) { try fm.removeItem(at: target) }
+        try fm.createDirectory(at: target, withIntermediateDirectories: true)
+        return try (1...count).map { i in
+            let url = target.appendingPathComponent(String(format: "fix-%02d.jpg", i))
+            try writeJPEG(
+                to: url,
+                hue: CGFloat(i - 1) / CGFloat(count),
+                exifDate: String(format: "2026:01:01 12:%02d:00", min(i, 59)))
+            return url
+        }
+    }
+
+    /// SHA-256 of a file's bytes, lowercase hex. Fixtures are tiny so a single
+    /// read is fine.
+    static func sha256(of url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func writeJPEG(to url: URL, hue: CGFloat, exifDate: String) throws {
+        let w = 640
+        let h = 480
+        guard
+            let ctx = CGContext(
+                data: nil, width: w, height: h, bitsPerComponent: 8, bytesPerRow: w * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { throw CocoaError(.fileWriteUnknown) }
+        ctx.setFillColor(NSColor(hue: hue, saturation: 0.8, brightness: 0.9, alpha: 1).cgColor)
+        ctx.fill(CGRect(x: 0, y: 0, width: w, height: h))
+        guard let image = ctx.makeImage(),
+            let dest = CGImageDestinationCreateWithURL(
+                url as CFURL, UTType.jpeg.identifier as CFString, 1, nil)
+        else { throw CocoaError(.fileWriteUnknown) }
+        let props: [CFString: Any] = [
+            kCGImagePropertyExifDictionary: [kCGImagePropertyExifDateTimeOriginal: exifDate]
+        ]
+        CGImageDestinationAddImage(dest, image, props as CFDictionary)
+        guard CGImageDestinationFinalize(dest) else { throw CocoaError(.fileWriteUnknown) }
+    }
+}

--- a/ImageIntactUITests/OpenPanelBackupUITests.swift
+++ b/ImageIntactUITests/OpenPanelBackupUITests.swift
@@ -104,7 +104,11 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
 
         button.click()
 
-        let panel = app.windows["open-panel"]
+        // ImageIntact opens the picker app-modally (NSOpenPanel.runModal), so it
+        // surfaces as a Dialog carrying the system identifier "open-panel" - not
+        // a Window, which is what a modeless begin{} panel (Palomino) would be.
+        // Verified against the xcresult UI hierarchy.
+        let panel = app.dialogs["open-panel"]
         XCTAssertTrue(panel.waitForExistence(timeout: 15), "open panel did not appear")
 
         // Go-To-Folder is a sheet ON the panel. The panel runs out of process

--- a/ImageIntactUITests/OpenPanelBackupUITests.swift
+++ b/ImageIntactUITests/OpenPanelBackupUITests.swift
@@ -8,10 +8,12 @@
 //  byte-verify the copied destination after the backup completes - ground
 //  truth instead of trusting the app's own completion stats. AMUX-371.
 //
-//  Driving patterns ported verbatim from Palomino (FolderTests): the panel is
-//  app.windows (not dialogs), Go-To-Folder is a sheet ON the panel, and the
-//  path is typed via the pasteboard + Cmd-V (the out-of-process panel drops
-//  char-by-char typing) with the clipboard saved and restored.
+//  Driving patterns ported from Palomino (FolderTests): Go-To-Folder is a sheet
+//  ON the panel, and the path is pasted via the pasteboard + Cmd-V (the
+//  out-of-process panel drops char-by-char typing) with the clipboard saved and
+//  restored. The one departure: ImageIntact opens the picker app-modally, so it
+//  surfaces as app.dialogs["open-panel"], not the app.windows["open-panel"] that
+//  Palomino's modeless begin{} picker produces.
 //
 
 import AppKit
@@ -31,8 +33,21 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
 
         let sourceFiles = try FixtureFactory.generateImages(into: sourceDir, count: 6)
         try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
-        // Only ever remove the marked root, and only after verification.
-        defer { try? FileManager.default.removeItem(at: root) }
+        // Clean up through a teardown block, not defer: with continueAfterFailure
+        // false a failed assertion halts the test via an Objective-C exception
+        // that bypasses Swift defer, which would leak the fixture tree. Teardown
+        // blocks still run. Only ever remove the marked root.
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        // Save and restore the clipboard at the test level (same reason: a defer
+        // in the paste helper would be skipped on a mid-helper failure). The UI
+        // plan is serial (TestPlans/UI.xctestplan), so there is no parallel-test
+        // race on the global pasteboard.
+        let savedClipboard = NSPasteboard.general.string(forType: .string)
+        addTeardownBlock {
+            NSPasteboard.general.clearContents()
+            if let savedClipboard { NSPasteboard.general.setString(savedClipboard, forType: .string) }
+        }
 
         let a = launchApp(fixtures: nil, hasSeenWelcome: true)
         let main = MainScreen(app: a)
@@ -94,13 +109,10 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
     /// (the out-of-process panel drops char-by-char typing), confirm the sheet,
     /// then Open. Saves and restores the clipboard.
     private func selectFolderViaOpenPanel(opening button: XCUIElement, to path: String) {
-        let savedClipboard = NSPasteboard.general.string(forType: .string)
+        // The path is pasted from the pasteboard (the out-of-process panel drops
+        // char-by-char typing); the caller saves and restores the clipboard.
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(path, forType: .string)
-        defer {
-            NSPasteboard.general.clearContents()
-            if let savedClipboard { NSPasteboard.general.setString(savedClipboard, forType: .string) }
-        }
 
         button.click()
 
@@ -111,8 +123,7 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
         let panel = app.dialogs["open-panel"]
         XCTAssertTrue(panel.waitForExistence(timeout: 15), "open panel did not appear")
 
-        // Go-To-Folder is a sheet ON the panel. The panel runs out of process
-        // and drops char-by-char typing, so paste the path from the pasteboard.
+        // Go-To-Folder is a sheet ON the panel.
         panel.typeKey("g", modifierFlags: [.command, .shift])
         let gotoSheet = panel.sheets.firstMatch
         XCTAssertTrue(gotoSheet.waitForExistence(timeout: 5), "Go-to-Folder sheet did not appear")
@@ -121,13 +132,19 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
         field.click()
         field.typeKey("a", modifierFlags: .command)
         field.typeKey("v", modifierFlags: .command)
+        // Confirm the Go-To-Folder sheet, which navigates the panel to the path.
         panel.typeKey(.return, modifierFlags: [])
+        // The navigation has no observable completion signal; give it a moment to
+        // settle so Open selects the navigated folder rather than the prior one.
         Thread.sleep(forTimeInterval: 1)
 
-        // Confirm the open panel itself, then let it dismiss before the caller
-        // drives the next selection.
-        if panel.exists && panel.buttons["Open"].exists {
-            panel.buttons["Open"].click()
+        // Confirm the panel via the Open button once it is present (waiting for it
+        // rather than checking immediately avoids a swallowed Return if the sheet
+        // is still animating out). Match on existence, not hittability: modal
+        // panel buttons misreport isHittable on macOS.
+        let openButton = panel.buttons["Open"]
+        if openButton.waitForExistence(timeout: 5) {
+            openButton.click()
         } else {
             panel.typeKey(.return, modifierFlags: [])
         }

--- a/ImageIntactUITests/OpenPanelBackupUITests.swift
+++ b/ImageIntactUITests/OpenPanelBackupUITests.swift
@@ -1,0 +1,127 @@
+//
+//  OpenPanelBackupUITests.swift
+//  ImageIntactUITests
+//
+//  The production-faithful complement to the seam-based backup tests: select
+//  the source and destination through the REAL NSOpenPanel (powerbox), with
+//  fixtures generated in the RUNNER's container so the runner can independently
+//  byte-verify the copied destination after the backup completes - ground
+//  truth instead of trusting the app's own completion stats. AMUX-371.
+//
+//  Driving patterns ported verbatim from Palomino (FolderTests): the panel is
+//  app.windows (not dialogs), Go-To-Folder is a sheet ON the panel, and the
+//  path is typed via the pasteboard + Cmd-V (the out-of-process panel drops
+//  char-by-char typing) with the clipboard saved and restored.
+//
+
+import XCTest
+
+final class OpenPanelBackupUITests: ImageIntactUITestCase {
+
+    func testBackup_ViaOpenPanel_RunnerByteVerifiesDestination() throws {
+        // Fixtures live in the RUNNER's container (NSTemporaryDirectory here is
+        // the runner's tmp). The sandboxed app cannot read them until the
+        // open-panel selection grants access - the real sandbox UX, and the
+        // reason the copied bytes end up somewhere the runner can read back.
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("imageintact-uitest-powerbox-\(UUID().uuidString)")
+        let sourceDir = root.appendingPathComponent("source")
+        let destDir = root.appendingPathComponent("dest1")
+
+        let sourceFiles = try FixtureFactory.generateImages(into: sourceDir, count: 6)
+        try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
+        // Only ever remove the marked root, and only after verification.
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let a = launchApp(fixtures: nil, hasSeenWelcome: true)
+        let main = MainScreen(app: a)
+        dumpElementTree(a, label: "powerbox-initial")
+
+        // Source: drive the real open panel from the unselected picker row.
+        let sourcePicker = main.folderRow("Select Source Folder")
+        if !sourcePicker.waitForExistence(timeout: 10) {
+            dumpElementTree(a, label: "powerbox-no-source-picker")
+            XCTFail("source picker button not shown; element tree dumped")
+            return
+        }
+        selectFolderViaOpenPanel(opening: sourcePicker, to: sourceDir.path)
+        // The real setSource path runs an async scan; wait for the row to flip
+        // to the selected folder's name before driving the destination.
+        XCTAssertTrue(
+            main.folderRow("source").waitForExistence(timeout: 30),
+            "source folder was not selected via the open panel")
+
+        // Destination: drive the real open panel from the blank Destination 1 row.
+        let destPicker = main.folderRow("Destination 1")
+        if !destPicker.waitForExistence(timeout: 10) {
+            dumpElementTree(a, label: "powerbox-no-dest-picker")
+            XCTFail("destination picker button not shown; element tree dumped")
+            return
+        }
+        selectFolderViaOpenPanel(opening: destPicker, to: destDir.path)
+        XCTAssertTrue(
+            main.folderRow("dest1").waitForExistence(timeout: 30),
+            "destination folder was not selected via the open panel")
+
+        // Run the backup through the real button.
+        XCTAssertTrue(waitUntilHittable(main.runBackupButton), "Run Backup never became clickable")
+        XCTAssertTrue(
+            main.runBackupButton.isEnabled, "Run Backup should be enabled with source + dest set")
+        main.runBackupButton.click()
+
+        let completion = CompletionSheet(app: a)
+        if !completion.marker.waitForExistence(timeout: 120) {
+            dumpElementTree(a, label: "powerbox-no-completion")
+            XCTFail("completion sheet never appeared; element tree dumped")
+            return
+        }
+        let stats = pollValue(of: completion.marker, timeout: 10) { !$0.isEmpty }
+        XCTAssertFalse(stats.isEmpty, "completion stats accessibility value is empty")
+        XCTAssertTrue(stats.contains("failed=0"), "backup reported failures: \(stats)")
+        XCTAssertTrue(stats.contains("inSource=6"), "expected 6 source files in stats: \(stats)")
+
+        // Ground truth: the runner independently recomputes the checksums of the
+        // copied files and matches them against the source fixtures. The
+        // container-fixture tests cannot do this (the runner cannot read the app
+        // container); here both trees live in the runner's container.
+        try assertDestinationMatchesSource(sourceFiles: sourceFiles, destRoot: destDir)
+    }
+
+    // MARK: - Open-panel driving (Palomino pattern)
+
+    /// Drives the real NSOpenPanel end to end: click the picker to open the
+    /// panel, Go-To-Folder (Cmd-Shift-G), paste the path through the pasteboard
+    /// (the out-of-process panel drops char-by-char typing), confirm the sheet,
+    /// then Open. Saves and restores the clipboard.
+    private func selectFolderViaOpenPanel(opening button: XCUIElement, to path: String) {
+        XCTFail("open-panel driving not implemented")
+    }
+
+    // MARK: - Runner-side byte verification
+
+    /// Walks the destination tree, maps every copied JPEG by name to its
+    /// SHA-256, and asserts each source fixture appears with byte-identical
+    /// content. Matching by content (not a hard-coded path) keeps the assertion
+    /// robust to the app's organization-folder layout and any sidecar files it
+    /// writes alongside the copies.
+    private func assertDestinationMatchesSource(sourceFiles: [URL], destRoot: URL) throws {
+        let fm = FileManager.default
+        var destByName: [String: String] = [:]
+        let keys: [URLResourceKey] = [.isRegularFileKey]
+        if let enumerator = fm.enumerator(at: destRoot, includingPropertiesForKeys: keys) {
+            for case let url as URL in enumerator where url.pathExtension.lowercased() == "jpg" {
+                destByName[url.lastPathComponent] = try FixtureFactory.sha256(of: url)
+            }
+        }
+        XCTAssertEqual(
+            destByName.count, sourceFiles.count,
+            "expected \(sourceFiles.count) copied JPEGs in the destination, found \(destByName.count)")
+        for src in sourceFiles {
+            let name = src.lastPathComponent
+            let srcSum = try FixtureFactory.sha256(of: src)
+            XCTAssertEqual(
+                destByName[name], srcSum,
+                "destination copy of \(name) is missing or byte-differs from the source fixture")
+        }
+    }
+}

--- a/ImageIntactUITests/OpenPanelBackupUITests.swift
+++ b/ImageIntactUITests/OpenPanelBackupUITests.swift
@@ -31,13 +31,15 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
         let sourceDir = root.appendingPathComponent("source")
         let destDir = root.appendingPathComponent("dest1")
 
-        let sourceFiles = try FixtureFactory.generateImages(into: sourceDir, count: 6)
-        try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
-        // Clean up through a teardown block, not defer: with continueAfterFailure
-        // false a failed assertion halts the test via an Objective-C exception
-        // that bypasses Swift defer, which would leak the fixture tree. Teardown
+        // Register cleanup BEFORE creating anything, so a throw during fixture
+        // generation still removes the partial tree. A teardown block (not defer)
+        // because continueAfterFailure is false: a failed assertion halts the
+        // test via an Objective-C exception that bypasses Swift defer; teardown
         // blocks still run. Only ever remove the marked root.
         addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let sourceFiles = try FixtureFactory.generateImages(into: sourceDir, count: 6)
+        try FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
 
         // Save and restore the clipboard at the test level (same reason: a defer
         // in the paste helper would be skipped on a mid-helper failure). The UI

--- a/ImageIntactUITests/OpenPanelBackupUITests.swift
+++ b/ImageIntactUITests/OpenPanelBackupUITests.swift
@@ -134,8 +134,10 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
         field.typeKey("v", modifierFlags: .command)
         // Confirm the Go-To-Folder sheet, which navigates the panel to the path.
         panel.typeKey(.return, modifierFlags: [])
-        // The navigation has no observable completion signal; give it a moment to
-        // settle so Open selects the navigated folder rather than the prior one.
+        // Wait for the sheet to actually dismiss before confirming, so Open is not
+        // clicked through a still-animating sheet. The folder navigation itself
+        // has no observable signal, so let it settle briefly afterward.
+        _ = gotoSheet.waitForNonExistence(timeout: 5)
         Thread.sleep(forTimeInterval: 1)
 
         // Confirm the panel via the Open button once it is present (waiting for it

--- a/ImageIntactUITests/OpenPanelBackupUITests.swift
+++ b/ImageIntactUITests/OpenPanelBackupUITests.swift
@@ -14,6 +14,7 @@
 //  char-by-char typing) with the clipboard saved and restored.
 //
 
+import AppKit
 import XCTest
 
 final class OpenPanelBackupUITests: ImageIntactUITestCase {
@@ -35,7 +36,6 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
 
         let a = launchApp(fixtures: nil, hasSeenWelcome: true)
         let main = MainScreen(app: a)
-        dumpElementTree(a, label: "powerbox-initial")
 
         // Source: drive the real open panel from the unselected picker row.
         let sourcePicker = main.folderRow("Select Source Folder")
@@ -94,7 +94,40 @@ final class OpenPanelBackupUITests: ImageIntactUITestCase {
     /// (the out-of-process panel drops char-by-char typing), confirm the sheet,
     /// then Open. Saves and restores the clipboard.
     private func selectFolderViaOpenPanel(opening button: XCUIElement, to path: String) {
-        XCTFail("open-panel driving not implemented")
+        let savedClipboard = NSPasteboard.general.string(forType: .string)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(path, forType: .string)
+        defer {
+            NSPasteboard.general.clearContents()
+            if let savedClipboard { NSPasteboard.general.setString(savedClipboard, forType: .string) }
+        }
+
+        button.click()
+
+        let panel = app.windows["open-panel"]
+        XCTAssertTrue(panel.waitForExistence(timeout: 15), "open panel did not appear")
+
+        // Go-To-Folder is a sheet ON the panel. The panel runs out of process
+        // and drops char-by-char typing, so paste the path from the pasteboard.
+        panel.typeKey("g", modifierFlags: [.command, .shift])
+        let gotoSheet = panel.sheets.firstMatch
+        XCTAssertTrue(gotoSheet.waitForExistence(timeout: 5), "Go-to-Folder sheet did not appear")
+        let field = gotoSheet.textFields.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 3), "Go-to-Folder field did not appear")
+        field.click()
+        field.typeKey("a", modifierFlags: .command)
+        field.typeKey("v", modifierFlags: .command)
+        panel.typeKey(.return, modifierFlags: [])
+        Thread.sleep(forTimeInterval: 1)
+
+        // Confirm the open panel itself, then let it dismiss before the caller
+        // drives the next selection.
+        if panel.exists && panel.buttons["Open"].exists {
+            panel.buttons["Open"].click()
+        } else {
+            panel.typeKey(.return, modifierFlags: [])
+        }
+        _ = panel.waitForNonExistence(timeout: 10)
     }
 
     // MARK: - Runner-side byte verification


### PR DESCRIPTION
## Summary

Adds the production-faithful complement to the seam-based backup UI tests (AMUX-371, gh#139). `OpenPanelBackupUITests` selects the source and destination through the real `NSOpenPanel` (powerbox) and, because the fixtures live in the test runner's own container, the runner independently recomputes SHA-256 checksums of the copied files and matches them against the source. That is ground truth, not the app's own completion stats.

This is the documented follow-up called out in `.planning/design/ui-test-suite.md` ("Powerbox open-panel production-faithful test with runner-side byte checks").

## What it proves

- Folder selection through the real modal `NSOpenPanel`, driven the way a user would: Go-To-Folder (Cmd-Shift-G), path pasted via the pasteboard, Open.
- The sandboxed app reads the source and writes the backup into the runner's container purely through the powerbox security-scoped grant, with no test seam bypass. The existing seam tests cannot verify the bytes because the runner cannot read the app's container; here both trees live in the runner's container.
- The 6 copied JPEGs are byte-identical to the source fixtures (SHA-256), checked by the runner after completion.

## Files

- `ImageIntactUITests/FixtureFactory.swift` (new): runner-side JPEG fixture generator with a path-marker safety guard, plus a SHA-256 helper. Ported from Palomino's FixtureFactory.
- `ImageIntactUITests/OpenPanelBackupUITests.swift` (new): the end-to-end test and the open-panel driving helper.

No app code changes. The existing seam tests are unchanged; they stay because they are faster and stabler.

## Notes for review

- FixtureFactory is a member of the UI test target only, not "both targets" as the Palomino pattern describes. The app already generates its in-container fixtures through `ImageIntact/Testing/UITestFixtures.swift`, so only the runner needs its own generator, and ImageIntact's Xcode 16 file-system-synchronized groups make cross-root target membership fragile and unnecessary here.
- ImageIntact opens the picker app-modally (`NSOpenPanel.runModal`), so the panel surfaces as a `Dialog` carrying the system identifier `open-panel`, not a `Window` (a modeless `begin{}` panel, as in Palomino, would be a Window). The query targets `app.dialogs["open-panel"]`, verified against the xcresult UI hierarchy.

## Test

Full unit + UI gate green on bot-mini via `imageintact-ui-gate.sh feat/ui-test-powerbox`: 16/16 UI tests pass (15 existing plus the new one), sha 1aafa85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
