### PR TITLE
UI test: renamed-duplicates path via Core Data seeding (AMUX-394)

### DIFF
--- a/ImageIntact/Testing/UITestFixtures.swift
+++ b/ImageIntact/Testing/UITestFixtures.swift
@@ -336,21 +336,35 @@ enum UITestSeam {
       let driveUUID = (try? destination.resourceValues(forKeys: [.volumeUUIDStringKey]))?
         .volumeUUIDString
       let orgDir = destination.appendingPathComponent(organizationName)
-      let context = EventLogger.shared.container.viewContext
+
+      // Compute checksums up front (file I/O), so the Core Data work below stays
+      // small and runs entirely on the context's own queue.
+      var seeds: [(checksum: String, fileName: String, destinationPath: String)] = []
       for (idx, file) in sourceFiles.enumerated() {
-        let checksum = try ChecksumService.sha256(for: file, shouldCancel: { false })
         let renamedName = String(format: "renamed-%02d.jpg", idx + 1)
-        let event = BackupEvent(context: context)
-        event.id = UUID()
-        event.timestamp = Date()
-        event.eventType = EventType.copy.rawValue
-        event.severity = EventSeverity.info.rawValue
-        event.checksum = checksum
-        event.fileName = renamedName
-        event.driveUUID = driveUUID
-        event.destinationPath = orgDir.appendingPathComponent(renamedName).path
+        let checksum = try ChecksumService.sha256(for: file, shouldCancel: { false })
+        seeds.append((checksum, renamedName, orgDir.appendingPathComponent(renamedName).path))
       }
-      try context.save()
+
+      // Always touch the main-queue viewContext through performAndWait so this is
+      // correct even if fixture generation is ever moved off the main thread.
+      let context = EventLogger.shared.container.viewContext
+      var saveError: Error?
+      context.performAndWait {
+        for seed in seeds {
+          let event = BackupEvent(context: context)
+          event.id = UUID()
+          event.timestamp = Date()
+          event.eventType = EventType.copy.rawValue
+          event.severity = EventSeverity.info.rawValue
+          event.checksum = seed.checksum
+          event.fileName = seed.fileName
+          event.driveUUID = driveUUID
+          event.destinationPath = seed.destinationPath
+        }
+        do { try context.save() } catch { saveError = error }
+      }
+      if let saveError { throw saveError }
     }
 
     private static func writeJPEG(to url: URL, hue: CGFloat, exifDate: String) throws {

--- a/ImageIntact/Testing/UITestFixtures.swift
+++ b/ImageIntact/Testing/UITestFixtures.swift
@@ -79,6 +79,7 @@ enum UITestSeam {
 
 #if DEBUG
   import AppKit
+  import CoreData
   import ImageIO
   import UniformTypeIdentifiers
 
@@ -114,6 +115,14 @@ enum UITestSeam {
       /// Copies of the source files at the destination ROOT with no
       /// organization folder — triggers the migration-dialog path.
       case loose
+      /// Same content as the source but recorded at the destination under a
+      /// DIFFERENT name — triggers the renamed-duplicate path. Detection is
+      /// Core-Data-backed (DuplicateDetector reads EventLogger's "copy" events,
+      /// not the destination filesystem), so this mode seeds a copy event per
+      /// file with a matching checksum but a differing fileName. The source
+      /// files use distinct content (a different EXIF year) so their checksums
+      /// never collide with the standard fixtures' accumulated records.
+      case renamed
     }
 
     struct GeneratedPaths {
@@ -149,7 +158,7 @@ enum UITestSeam {
 
     // MARK: - Spec parsing
 
-    /// Grammar: `src=<1...999>[,dests=<1...8>][,prefill=none|exact|loose][,failures=<0...src>][,videos=<0...999>]`
+    /// Grammar: `src=<1...999>[,dests=<1...8>][,prefill=none|exact|loose|renamed][,failures=<0...src>][,videos=<0...999>]`
     static func parseSpec(_ raw: String) -> Spec? {
       var sourceCount: Int?
       var destCount = 1
@@ -220,12 +229,17 @@ enum UITestSeam {
       let source = dir.appendingPathComponent("source")
       try fm.createDirectory(at: source, withIntermediateDirectories: true)
       var sourceFiles: [URL] = []
+      // Renamed-duplicate fixtures use distinct content (a different EXIF year)
+      // so their checksums never collide with the standard (2026) fixtures whose
+      // "copy" records accumulate in the shared EventLogger store — otherwise a
+      // colliding same-name record could classify them exact instead of renamed.
+      let exifYear = spec.prefill == .renamed ? "2024" : "2026"
       for i in 1...spec.sourceCount {
         let url = source.appendingPathComponent(String(format: "fix-%02d.jpg", i))
         try writeJPEG(
           to: url,
           hue: CGFloat(i - 1) / CGFloat(spec.sourceCount),
-          exifDate: String(format: "2026:01:01 12:%02d:00", min(i, 59)))
+          exifDate: String(format: "\(exifYear):01:01 12:%02d:00", min(i, 59)))
         sourceFiles.append(url)
       }
 
@@ -257,6 +271,19 @@ enum UITestSeam {
           for file in sourceFiles {
             try fm.copyItem(at: file, to: dest.appendingPathComponent(file.lastPathComponent))
           }
+        case .renamed:
+          // Disk: place same-content copies under DIFFERENT names in the org
+          // folder (faithful to a renamed-on-disk duplicate).
+          let orgDir = dest.appendingPathComponent(organizationName)
+          try fm.createDirectory(at: orgDir, withIntermediateDirectories: true)
+          for (idx, file) in sourceFiles.enumerated() {
+            let renamedName = String(format: "renamed-%02d.jpg", idx + 1)
+            try fm.copyItem(at: file, to: orgDir.appendingPathComponent(renamedName))
+          }
+          // Detection reads Core Data, not the disk, so seed a "copy" event per
+          // file: matching checksum, DIFFERENT fileName -> classified renamed.
+          try seedRenamedDuplicateRecords(
+            sourceFiles: sourceFiles, destination: dest, organizationName: organizationName)
         }
         dests.append(dest)
       }
@@ -290,6 +317,40 @@ enum UITestSeam {
         }
         try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
       }
+    }
+
+    /// Seeds the duplicate detector's Core Data store with one "copy" event per
+    /// source file: a MATCHING checksum (so it is a duplicate) but a DIFFERENT
+    /// fileName (so `DuplicateDetector` classifies it renamed, not exact).
+    ///
+    /// `DuplicateDetector.queryExistingFiles` reads EventLogger's store (NOT the
+    /// destination filesystem) and matches on the destination's volume UUID, then
+    /// compares the stored `fileName` to the source filename. So we mirror exactly
+    /// what a real backup records (`BatchEventLogger`): eventType=copy,
+    /// severity=info, checksum, fileName, driveUUID. `session` is optional in the
+    /// model, so it is omitted. The checksum is computed with the same
+    /// `ChecksumService` the manifest uses, guaranteeing the match.
+    private static func seedRenamedDuplicateRecords(
+      sourceFiles: [URL], destination: URL, organizationName: String
+    ) throws {
+      let driveUUID = (try? destination.resourceValues(forKeys: [.volumeUUIDStringKey]))?
+        .volumeUUIDString
+      let orgDir = destination.appendingPathComponent(organizationName)
+      let context = EventLogger.shared.container.viewContext
+      for (idx, file) in sourceFiles.enumerated() {
+        let checksum = try ChecksumService.sha256(for: file, shouldCancel: { false })
+        let renamedName = String(format: "renamed-%02d.jpg", idx + 1)
+        let event = BackupEvent(context: context)
+        event.id = UUID()
+        event.timestamp = Date()
+        event.eventType = EventType.copy.rawValue
+        event.severity = EventSeverity.info.rawValue
+        event.checksum = checksum
+        event.fileName = renamedName
+        event.driveUUID = driveUUID
+        event.destinationPath = orgDir.appendingPathComponent(renamedName).path
+      }
+      try context.save()
     }
 
     private static func writeJPEG(to url: URL, hue: CGFloat, exifDate: String) throws {

--- a/ImageIntactUITests/DuplicateWarningUITests.swift
+++ b/ImageIntactUITests/DuplicateWarningUITests.swift
@@ -179,8 +179,9 @@ final class DuplicateWarningUITests: ImageIntactUITestCase {
       duplicate.button("Continue with Selection").exists, "Continue with Selection button missing")
     XCTAssertTrue(duplicate.button("Cancel Backup").exists, "Cancel Backup button missing")
 
-    // Cancel rather than proceed: this test only asserts detection, and
-    // cancelling copies nothing, so it leaves no copy records behind.
+    // Cancel rather than proceed: this test only asserts detection. Cancelling
+    // copies nothing, so it adds no NEW copy records beyond the ones the fixture
+    // seam already seeded for renamed-duplicate detection.
     duplicate.button("Cancel Backup").click()
     XCTAssertTrue(
       duplicate.marker.waitForNonExistence(timeout: 10),
@@ -190,8 +191,8 @@ final class DuplicateWarningUITests: ImageIntactUITestCase {
   func testSkipRenamedDuplicates_TogglesCheckbox_ProceedsWithoutLooping() throws {
     let (a, duplicate) = launchToRenamedDuplicateSheet()
 
-    // Turn ON "Skip renamed duplicates" (defaults off). The custom checkbox-style
-    // Toggle surfaces as an app.checkBox; match it by its "renamed" label.
+    // Turn ON "Skip renamed duplicates". The custom checkbox-style Toggle
+    // surfaces as an app.checkBox; match it by its "renamed" label.
     let skipRenamed = a.sheets.checkBoxes
       .matching(NSPredicate(format: "label CONTAINS[c] %@", "renamed")).firstMatch
     if !skipRenamed.waitForExistence(timeout: 5) {
@@ -199,7 +200,11 @@ final class DuplicateWarningUITests: ImageIntactUITestCase {
       XCTFail("Skip renamed duplicates checkbox not found; element tree dumped")
       return
     }
-    if (skipRenamed.value as? String) != "1" { skipRenamed.click() }
+    // It defaults OFF on a fresh (hermetic) launch, so a single click turns it
+    // on. We click unconditionally rather than reading `.value` — a macOS
+    // checkbox's value can be an NSNumber, not a String, so an `as? String`
+    // guard would misfire.
+    skipRenamed.click()
 
     duplicate.button("Continue with Selection").click()
 

--- a/ImageIntactUITests/DuplicateWarningUITests.swift
+++ b/ImageIntactUITests/DuplicateWarningUITests.swift
@@ -139,4 +139,78 @@ final class DuplicateWarningUITests: ImageIntactUITestCase {
     XCTAssertTrue(waitUntilHittable(main.runBackupButton), "Run Backup not clickable after cancel")
     XCTAssertTrue(main.runBackupButton.isEnabled, "Run Backup disabled after cancel")
   }
+
+  // MARK: - Renamed duplicates (AMUX-394)
+
+  /// Launches with renamed duplicates: the source files have distinct content
+  /// and the detector's Core Data store is seeded with copy records under
+  /// DIFFERENT names, so preflight reports them as renamed (not exact).
+  @discardableResult
+  private func launchToRenamedDuplicateSheet() -> (XCUIApplication, DuplicateSheet) {
+    let a = launchApp(
+      fixtures: "src=6,dests=1,prefill=renamed",
+      organization: "UITestOrg",
+      extraArgs: ["-enableSmartDuplicateDetection", "YES"])
+    let main = MainScreen(app: a)
+
+    if !main.folderRow("source").waitForExistence(timeout: 12) {
+      dumpElementTree(a, label: "renamed-no-source-row")
+      XCTFail("seam-selected source folder is not shown in the UI; element tree dumped")
+    }
+    XCTAssertTrue(waitUntilHittable(main.runBackupButton), "Run Backup never became clickable")
+    main.runBackupButton.click()
+
+    let duplicate = DuplicateSheet(app: a)
+    if !duplicate.marker.waitForExistence(timeout: 30) {
+      dumpElementTree(a, label: "renamed-no-sheet")
+      XCTFail("duplicate warning sheet marker never appeared; element tree dumped")
+    }
+    return (a, duplicate)
+  }
+
+  func testDuplicateSheet_AppearsWithRenamedDuplicates_NotExact() throws {
+    let (_, duplicate) = launchToRenamedDuplicateSheet()
+
+    let info = pollValue(of: duplicate.marker, timeout: 10) { !$0.isEmpty }
+    XCTAssertTrue(info.contains("renamed=6"), "expected 6 renamed duplicates in marker: \(info)")
+    XCTAssertTrue(info.contains("exact=0"), "expected no exact duplicates in marker: \(info)")
+
+    XCTAssertTrue(
+      duplicate.button("Continue with Selection").exists, "Continue with Selection button missing")
+    XCTAssertTrue(duplicate.button("Cancel Backup").exists, "Cancel Backup button missing")
+
+    // Cancel rather than proceed: this test only asserts detection, and
+    // cancelling copies nothing, so it leaves no copy records behind.
+    duplicate.button("Cancel Backup").click()
+    XCTAssertTrue(
+      duplicate.marker.waitForNonExistence(timeout: 10),
+      "duplicate sheet did not dismiss after Cancel Backup")
+  }
+
+  func testSkipRenamedDuplicates_TogglesCheckbox_ProceedsWithoutLooping() throws {
+    let (a, duplicate) = launchToRenamedDuplicateSheet()
+
+    // Turn ON "Skip renamed duplicates" (defaults off). The custom checkbox-style
+    // Toggle surfaces as an app.checkBox; match it by its "renamed" label.
+    let skipRenamed = a.sheets.checkBoxes
+      .matching(NSPredicate(format: "label CONTAINS[c] %@", "renamed")).firstMatch
+    if !skipRenamed.waitForExistence(timeout: 5) {
+      dumpElementTree(a, label: "renamed-no-skip-checkbox")
+      XCTFail("Skip renamed duplicates checkbox not found; element tree dumped")
+      return
+    }
+    if (skipRenamed.value as? String) != "1" { skipRenamed.click() }
+
+    duplicate.button("Continue with Selection").click()
+
+    // The proceed path must enter without re-presenting the sheet (gh#141 is
+    // fixed): the duplicate sheet dismisses and the backup reaches completion.
+    XCTAssertTrue(
+      duplicate.marker.waitForNonExistence(timeout: 15),
+      "duplicate sheet re-presented or never dismissed after Continue with Selection")
+    let completion = CompletionSheet(app: a)
+    XCTAssertTrue(
+      completion.marker.waitForExistence(timeout: 45),
+      "backup did not complete after skipping renamed duplicates")
+  }
 }


### PR DESCRIPTION
## What
Covers the **renamed-duplicates** path in `DuplicateWarningUITests` (gh #139 / AMUX-394), previously exact-only.

## Why the original premise didn't work (re-scoped)
The ticket assumed `prefill=renamed` = "copy source files to the dest under different names." But `DuplicateDetector.queryExistingFiles` reads EventLogger's **Core Data** `BackupEvent` copy records — **not** the destination filesystem (verified against the live store: matches on the dest volume `driveUUID` + `checksum`, compares the stored `fileName` to the source name). Copying differently-named files to disk creates no such record. So (per Konrad) the ticket was re-scoped to **seed Core Data**.

## How
`prefill=renamed` (`UITestFixtures`):
1. Generates source files with **distinct content** (EXIF year 2024 vs the standard 2026) so their checksums never collide with the accumulated `fix-NN.jpg` copy records (the detector keeps one record per checksum; a colliding same-name record would mis-classify them exact).
2. Copies the same content to the dest org folder under **different** names.
3. Seeds one `BackupEvent` per file mirroring `BatchEventLogger`: `eventType=copy`, `severity=info`, `checksum=ChecksumService.sha256(source)` (the same function the manifest uses → guaranteed match), `fileName=renamed-NN.jpg` (≠ source → renamed), `driveUUID=<dest volume>`. `session` is optional in the model, so omitted.

**The exact path is untouched** (no Core Data clearing, no change to `prefill=exact`).

## Tests (`DuplicateWarningUITests.swift`)
- `testDuplicateSheet_AppearsWithRenamedDuplicates_NotExact` — `renamed=6;exact=0`, then Cancel (no copy → no pollution).
- `testSkipRenamedDuplicates_TogglesCheckbox_ProceedsWithoutLooping` — toggles the "Skip renamed duplicates" checkbox, Continue with Selection, asserts the sheet dismisses (gh#141) and the backup completes.

## Verification
Full UI gate green. **All 4 existing exact `DuplicateWarningUITests` pass** (proof the seeding didn't disturb the shared path) **and** both new renamed tests pass.

Refs: AMUX-394 · Tonal-Photo/ImageIntact#139