### PR TITLE
UI tests: menu-bar command coverage (AMUX-462)

### DIFF
--- a/ImageIntactUITests/MenuCommandUITests.swift
+++ b/ImageIntactUITests/MenuCommandUITests.swift
@@ -94,19 +94,14 @@ final class MenuCommandUITests: ImageIntactUITestCase {
       return XCTFail("About item not clickable in the app menu")
     }
 
-    // The standard About panel opens as a separate window/dialog (its title is
-    // not the main content window's). Assert the surface COUNT increases after
-    // the click — a bare `count > 1` can pass on a pre-existing extra window.
-    let baselineSurfaces = a.windows.count + a.dialogs.count
-    let deadline = Date().addingTimeInterval(10)
-    var appeared = false
-    while Date() < deadline {
-      if a.windows.count + a.dialogs.count > baselineSurfaces { appeared = true; break }
-      Thread.sleep(forTimeInterval: 0.2)
-    }
-    if !appeared {
+    // The standard About panel (orderFrontStandardAboutPanel:) opens as a Dialog
+    // carrying a "Version x" static text. Assert that version text so the pass
+    // is specific to the About panel, not any incidental dialog.
+    let aboutVersion = a.dialogs.staticTexts.matching(
+      NSPredicate(format: "value BEGINSWITH %@", "Version")).firstMatch
+    if !aboutVersion.waitForExistence(timeout: 10) {
       dumpElementTree(a, label: "about-no-panel")
-      XCTFail("About panel did not appear (no new window/dialog after the menu click)")
+      XCTFail("About panel (version text) did not appear after the menu click")
       return
     }
     a.typeKey("w", modifierFlags: .command)  // close the panel

--- a/ImageIntactUITests/MenuCommandUITests.swift
+++ b/ImageIntactUITests/MenuCommandUITests.swift
@@ -95,11 +95,18 @@ final class MenuCommandUITests: ImageIntactUITestCase {
     }
 
     // The standard About panel opens as a separate window/dialog (its title is
-    // not the main content window's), so assert a new top-level surface appears.
-    let appeared = a.dialogs.firstMatch.waitForExistence(timeout: 8) || a.windows.count > 1
+    // not the main content window's). Assert the surface COUNT increases after
+    // the click — a bare `count > 1` can pass on a pre-existing extra window.
+    let baselineSurfaces = a.windows.count + a.dialogs.count
+    let deadline = Date().addingTimeInterval(10)
+    var appeared = false
+    while Date() < deadline {
+      if a.windows.count + a.dialogs.count > baselineSurfaces { appeared = true; break }
+      Thread.sleep(forTimeInterval: 0.2)
+    }
     if !appeared {
       dumpElementTree(a, label: "about-no-panel")
-      XCTFail("About panel did not appear")
+      XCTFail("About panel did not appear (no new window/dialog after the menu click)")
       return
     }
     a.typeKey("w", modifierFlags: .command)  // close the panel
@@ -236,14 +243,18 @@ final class MenuCommandUITests: ImageIntactUITestCase {
       return XCTFail("Help > ImageIntact Help not clickable")
     }
 
-    // HelpWindowManager opens an NSWindow titled "ImageIntact Help".
-    let helpWindow = a.windows["ImageIntact Help"]
-    if !helpWindow.waitForExistence(timeout: 10) {
+    // HelpWindowManager opens an NSWindow whose NSWindow.title is "ImageIntact
+    // Help", but HelpWindowView shows its default "What's New" section, so the
+    // displayed window title is version-dependent ("What's New – Version x").
+    // Identify the window by its unique "Search Help" field instead.
+    let helpSearch = a.searchFields.matching(
+      NSPredicate(format: "placeholderValue == %@", "Search Help")).firstMatch
+    if !helpSearch.waitForExistence(timeout: 10) {
       dumpElementTree(a, label: "help-no-window")
-      XCTFail("ImageIntact Help window did not appear")
+      XCTFail("Help window (Search Help field) did not appear")
       return
     }
-    helpWindow.typeKey("w", modifierFlags: .command)
+    a.typeKey("w", modifierFlags: .command)  // close the help window
   }
 
   // MARK: - Custom ImageIntact menu: Run Backup matches the button/File command

--- a/ImageIntactUITests/MenuCommandUITests.swift
+++ b/ImageIntactUITests/MenuCommandUITests.swift
@@ -50,20 +50,36 @@ final class MenuCommandUITests: ImageIntactUITestCase {
     return true
   }
 
-  /// The custom CommandMenu("ImageIntact"), disambiguated from the bold app menu
-  /// (both titled "ImageIntact") by the custom-only "Verify Core Data Storage"
-  /// item it exposes. Leaves the menu open on success.
+  /// Opens `parent`, then clicks the descendant menu item titled `title`. Menu
+  /// items report a degenerate (offscreen/zero) frame until their menu is open
+  /// and rendered, so clicking before then throws an INFINITY-point exception;
+  /// waiting until the item is genuinely hittable avoids that. Returns false
+  /// (after a dump) if the item never becomes hittable.
+  @discardableResult
+  private func clickItem(
+    _ a: XCUIApplication, in parent: XCUIElement, _ title: String, label: String
+  ) -> Bool {
+    guard open(a, parent, label) else { return false }
+    let item = parent.menuItems[title]
+    guard item.waitForExistence(timeout: 5), waitUntilHittable(item, timeout: 5) else {
+      dumpElementTree(a, label: "menu-item-not-hittable-\(label)")
+      return false
+    }
+    item.click()
+    return true
+  }
+
+  /// The custom CommandMenu("ImageIntact") menu-bar item, disambiguated from the
+  /// bold app menu (both titled "ImageIntact") by the custom-only "Verify Core
+  /// Data Storage" command. The probe is SCOPED to each candidate's descendants:
+  /// an unscoped `a.menuItems[...]` query matches app-wide and so resolves true
+  /// for the wrong menu-bar item. Does not open the menu.
   private func customMenu(_ a: XCUIApplication) -> XCUIElement? {
     let candidates = a.menuBars.menuBarItems.matching(
       NSPredicate(format: "title == %@", "ImageIntact"))
     for i in 0..<candidates.count {
       let item = candidates.element(boundBy: i)
-      guard item.exists else { continue }
-      item.click()
-      if a.menuItems["Verify Core Data Storage"].waitForExistence(timeout: 2) {
-        return item
-      }
-      if item.isSelected { item.click() }  // close before trying the next
+      if item.menuItems["Verify Core Data Storage"].exists { return item }
     }
     return nil
   }
@@ -72,22 +88,21 @@ final class MenuCommandUITests: ImageIntactUITestCase {
 
   func testAppMenu_About_ShowsAboutPanel() throws {
     let a = launchApp(fixtures: nil)
-    guard open(a, appMenu(a), "app") else {
-      return XCTFail("application menu not found")
+    // "About ImageIntact" is the first item of the bold app menu. Scope the
+    // click to that menu — an app-wide query resolves a degenerate-frame item.
+    guard clickItem(a, in: appMenu(a), "About ImageIntact", label: "about") else {
+      return XCTFail("About item not clickable in the app menu")
     }
-    let about = a.menuItems.matching(
-      NSPredicate(format: "title BEGINSWITH %@", "About")).firstMatch
-    XCTAssertTrue(about.waitForExistence(timeout: 5), "About item missing from the app menu")
-    about.click()
 
-    // The standard About panel surfaces as a window titled "About ImageIntact".
-    let panel = a.windows["About ImageIntact"]
-    if !panel.waitForExistence(timeout: 10) {
+    // The standard About panel opens as a separate window/dialog (its title is
+    // not the main content window's), so assert a new top-level surface appears.
+    let appeared = a.dialogs.firstMatch.waitForExistence(timeout: 8) || a.windows.count > 1
+    if !appeared {
       dumpElementTree(a, label: "about-no-panel")
       XCTFail("About panel did not appear")
       return
     }
-    panel.typeKey("w", modifierFlags: .command)  // close it
+    a.typeKey("w", modifierFlags: .command)  // close the panel
   }
 
   // MARK: - App menu: Preferences
@@ -217,10 +232,9 @@ final class MenuCommandUITests: ImageIntactUITestCase {
     let a = launchApp(fixtures: nil)
     XCTAssertTrue(MainScreen(app: a).runBackupButton.waitForExistence(timeout: 10))
 
-    guard open(a, menu(a, "Help"), "help") else { return XCTFail("Help menu not found") }
-    let help = menu(a, "Help").menuItems["ImageIntact Help"]
-    XCTAssertTrue(help.waitForExistence(timeout: 5), "Help > ImageIntact Help missing")
-    help.click()
+    guard clickItem(a, in: menu(a, "Help"), "ImageIntact Help", label: "help") else {
+      return XCTFail("Help > ImageIntact Help not clickable")
+    }
 
     // HelpWindowManager opens an NSWindow titled "ImageIntact Help".
     let helpWindow = a.windows["ImageIntact Help"]
@@ -244,9 +258,9 @@ final class MenuCommandUITests: ImageIntactUITestCase {
       XCTFail("custom ImageIntact menu (with Verify Core Data Storage) not found")
       return
     }
-    let run = menuItem.menuItems["Run Backup"]
-    XCTAssertTrue(run.waitForExistence(timeout: 5), "ImageIntact > Run Backup missing")
-    run.click()
+    guard clickItem(a, in: menuItem, "Run Backup", label: "custom-run") else {
+      return XCTFail("ImageIntact > Run Backup not clickable")
+    }
 
     let completion = CompletionSheet(app: a)
     if !completion.marker.waitForExistence(timeout: 120) {

--- a/ImageIntactUITests/MenuCommandUITests.swift
+++ b/ImageIntactUITests/MenuCommandUITests.swift
@@ -1,0 +1,257 @@
+//
+//  MenuCommandUITests.swift
+//  ImageIntactUITests
+//
+//  Drives the SwiftUI `Commands` menu surface (app / File / Edit / Help and the
+//  custom "ImageIntact" menu) and asserts each actionable command triggers its
+//  effect. The menu tree is enumerated from ImageIntactApp.swift, not guessed.
+//
+//  Design + the full covered/excluded command list and menu-disambiguation
+//  rationale: .planning/design/ui-test-suite.md
+//  ("2026-06-20 - Menu-bar command coverage").
+//
+//  Key gotchas (see design doc):
+//    - TWO menu-bar items are titled "ImageIntact": the bold app menu and the
+//      custom CommandMenu("ImageIntact"). The app menu is element(boundBy: 1)
+//      (Apple menu is 0); the custom menu is the one exposing the custom-only
+//      "Verify Core Data Storage" item.
+//    - Run Backup / Add Destination / Clear All / Select Source/Dest are each in
+//      two menus, so a bare app.menuItems["X"] is ambiguous. Every item click is
+//      scoped to its parent menu-bar item's descendants.
+//    - Menu items only populate once their parent menu is opened.
+//
+
+import XCTest
+
+final class MenuCommandUITests: ImageIntactUITestCase {
+
+  // MARK: - Menu helpers
+
+  /// The bold application menu (carries About + Preferences). Always the
+  /// menu-bar item right after the Apple menu (index 0).
+  private func appMenu(_ a: XCUIApplication) -> XCUIElement {
+    a.menuBars.menuBarItems.element(boundBy: 1)
+  }
+
+  /// A top-level menu-bar item by title (File / Edit / Help). Unique titles.
+  private func menu(_ a: XCUIApplication, _ title: String) -> XCUIElement {
+    a.menuBars.menuBarItems[title]
+  }
+
+  /// Opens a menu-bar item so its items populate. Returns false (after dumping)
+  /// if the item never appears.
+  @discardableResult
+  private func open(_ a: XCUIApplication, _ menuItem: XCUIElement, _ label: String) -> Bool {
+    guard menuItem.waitForExistence(timeout: 10) else {
+      dumpElementTree(a, label: "menu-missing-\(label)")
+      return false
+    }
+    menuItem.click()
+    return true
+  }
+
+  /// The custom CommandMenu("ImageIntact"), disambiguated from the bold app menu
+  /// (both titled "ImageIntact") by the custom-only "Verify Core Data Storage"
+  /// item it exposes. Leaves the menu open on success.
+  private func customMenu(_ a: XCUIApplication) -> XCUIElement? {
+    let candidates = a.menuBars.menuBarItems.matching(
+      NSPredicate(format: "title == %@", "ImageIntact"))
+    for i in 0..<candidates.count {
+      let item = candidates.element(boundBy: i)
+      guard item.exists else { continue }
+      item.click()
+      if a.menuItems["Verify Core Data Storage"].waitForExistence(timeout: 2) {
+        return item
+      }
+      if item.isSelected { item.click() }  // close before trying the next
+    }
+    return nil
+  }
+
+  // MARK: - App menu: About
+
+  func testAppMenu_About_ShowsAboutPanel() throws {
+    let a = launchApp(fixtures: nil)
+    guard open(a, appMenu(a), "app") else {
+      return XCTFail("application menu not found")
+    }
+    let about = a.menuItems.matching(
+      NSPredicate(format: "title BEGINSWITH %@", "About")).firstMatch
+    XCTAssertTrue(about.waitForExistence(timeout: 5), "About item missing from the app menu")
+    about.click()
+
+    // The standard About panel surfaces as a window titled "About ImageIntact".
+    let panel = a.windows["About ImageIntact"]
+    if !panel.waitForExistence(timeout: 10) {
+      dumpElementTree(a, label: "about-no-panel")
+      XCTFail("About panel did not appear")
+      return
+    }
+    panel.typeKey("w", modifierFlags: .command)  // close it
+  }
+
+  // MARK: - App menu: Preferences
+
+  func testAppMenu_Preferences_OpensPreferences() throws {
+    let a = launchApp(fixtures: nil)
+    guard open(a, appMenu(a), "app") else {
+      return XCTFail("application menu not found")
+    }
+    let prefs = a.menuItems.matching(
+      NSPredicate(format: "title BEGINSWITH %@ OR title BEGINSWITH %@", "Preferences", "Settings")
+    ).firstMatch
+    XCTAssertTrue(prefs.waitForExistence(timeout: 5), "Preferences item missing from the app menu")
+    prefs.click()
+
+    let close = a.sheets.buttons["Close"].firstMatch
+    XCTAssertTrue(close.waitForExistence(timeout: 10), "Preferences sheet did not open")
+    close.click()
+  }
+
+  // MARK: - File menu: Add Destination
+
+  func testFileMenu_AddDestination_GrowsDestinationRows() throws {
+    let a = launchApp(fixtures: nil)
+    let main = MainScreen(app: a)
+    XCTAssertTrue(main.runBackupButton.waitForExistence(timeout: 10))
+    XCTAssertFalse(
+      a.windows.buttons["Destination 2"].exists, "should start with one destination row")
+
+    guard open(a, menu(a, "File"), "file") else { return XCTFail("File menu not found") }
+    let add = menu(a, "File").menuItems["Add Destination"]
+    XCTAssertTrue(add.waitForExistence(timeout: 5), "File > Add Destination missing")
+    add.click()
+
+    XCTAssertTrue(
+      a.windows.buttons["Destination 2"].waitForExistence(timeout: 5),
+      "File > Add Destination did not add a second destination row")
+  }
+
+  // MARK: - File menu: Run Backup
+
+  func testFileMenu_RunBackup_StartsBackup() throws {
+    let a = launchApp(fixtures: "src=6,dests=1")
+    let main = MainScreen(app: a)
+    XCTAssertTrue(main.folderRow("source").waitForExistence(timeout: 10), "seam source missing")
+
+    guard open(a, menu(a, "File"), "file") else { return XCTFail("File menu not found") }
+    let run = menu(a, "File").menuItems["Run Backup"]
+    XCTAssertTrue(run.waitForExistence(timeout: 5), "File > Run Backup missing")
+    run.click()
+
+    let completion = CompletionSheet(app: a)
+    if !completion.marker.waitForExistence(timeout: 120) {
+      dumpElementTree(a, label: "file-runbackup-no-completion")
+      XCTFail("File > Run Backup did not reach a completion sheet")
+    }
+  }
+
+  // MARK: - File menu: Select Source Folder opens the open panel
+
+  func testFileMenu_SelectSource_OpensOpenPanel() throws {
+    let a = launchApp(fixtures: nil)
+    XCTAssertTrue(MainScreen(app: a).runBackupButton.waitForExistence(timeout: 10))
+
+    guard open(a, menu(a, "File"), "file") else { return XCTFail("File menu not found") }
+    let select = menu(a, "File").menuItems["Select Source Folder"]
+    XCTAssertTrue(select.waitForExistence(timeout: 5), "File > Select Source Folder missing")
+    select.click()
+
+    // App-modal NSOpenPanel surfaces as a Dialog with the system id "open-panel"
+    // (see OpenPanelBackupUITests). We only prove the command opens it, then
+    // cancel — folder selection itself is AMUX-371's coverage.
+    let panel = a.dialogs["open-panel"]
+    if !panel.waitForExistence(timeout: 15) {
+      dumpElementTree(a, label: "select-source-no-panel")
+      XCTFail("Select Source Folder did not open the open panel")
+      return
+    }
+    panel.buttons["Cancel"].click()
+  }
+
+  // MARK: - File menu: Select First Destination opens the open panel
+
+  func testFileMenu_SelectDestination_OpensOpenPanel() throws {
+    // Handler opens the panel only when destinationURLs is non-empty, so seed
+    // one seam destination.
+    let a = launchApp(fixtures: "src=6,dests=1")
+    XCTAssertTrue(
+      MainScreen(app: a).folderRow("dest1").waitForExistence(timeout: 10), "seam dest1 missing")
+
+    guard open(a, menu(a, "File"), "file") else { return XCTFail("File menu not found") }
+    let select = menu(a, "File").menuItems["Select First Destination"]
+    XCTAssertTrue(select.waitForExistence(timeout: 5), "File > Select First Destination missing")
+    select.click()
+
+    let panel = a.dialogs["open-panel"]
+    if !panel.waitForExistence(timeout: 15) {
+      dumpElementTree(a, label: "select-dest-no-panel")
+      XCTFail("Select First Destination did not open the open panel")
+      return
+    }
+    panel.buttons["Cancel"].click()
+  }
+
+  // MARK: - Edit menu: Clear All Selections
+
+  func testEditMenu_ClearAll_ClearsSelections() throws {
+    let a = launchApp(fixtures: "src=6,dests=1")
+    let main = MainScreen(app: a)
+    XCTAssertTrue(main.folderRow("source").waitForExistence(timeout: 10), "seam source missing")
+    XCTAssertTrue(main.folderRow("dest1").exists, "seam dest1 missing")
+
+    guard open(a, menu(a, "Edit"), "edit") else { return XCTFail("Edit menu not found") }
+    let clear = menu(a, "Edit").menuItems["Clear All Selections"]
+    XCTAssertTrue(clear.waitForExistence(timeout: 5), "Edit > Clear All Selections missing")
+    clear.click()
+
+    XCTAssertTrue(
+      main.folderRow("source").waitForNonExistence(timeout: 10),
+      "source row should clear after Clear All Selections")
+    XCTAssertFalse(main.folderRow("dest1").exists, "dest1 row should clear after Clear All")
+  }
+
+  // MARK: - Help menu: ImageIntact Help
+
+  func testHelpMenu_Help_OpensHelpWindow() throws {
+    let a = launchApp(fixtures: nil)
+    XCTAssertTrue(MainScreen(app: a).runBackupButton.waitForExistence(timeout: 10))
+
+    guard open(a, menu(a, "Help"), "help") else { return XCTFail("Help menu not found") }
+    let help = menu(a, "Help").menuItems["ImageIntact Help"]
+    XCTAssertTrue(help.waitForExistence(timeout: 5), "Help > ImageIntact Help missing")
+    help.click()
+
+    // HelpWindowManager opens an NSWindow titled "ImageIntact Help".
+    let helpWindow = a.windows["ImageIntact Help"]
+    if !helpWindow.waitForExistence(timeout: 10) {
+      dumpElementTree(a, label: "help-no-window")
+      XCTFail("ImageIntact Help window did not appear")
+      return
+    }
+    helpWindow.typeKey("w", modifierFlags: .command)
+  }
+
+  // MARK: - Custom ImageIntact menu: Run Backup matches the button/File command
+
+  func testImageIntactMenu_RunBackup_StartsBackup() throws {
+    let a = launchApp(fixtures: "src=6,dests=1")
+    let main = MainScreen(app: a)
+    XCTAssertTrue(main.folderRow("source").waitForExistence(timeout: 10), "seam source missing")
+
+    guard let menuItem = customMenu(a) else {
+      dumpElementTree(a, label: "custom-menu-not-found")
+      XCTFail("custom ImageIntact menu (with Verify Core Data Storage) not found")
+      return
+    }
+    let run = menuItem.menuItems["Run Backup"]
+    XCTAssertTrue(run.waitForExistence(timeout: 5), "ImageIntact > Run Backup missing")
+    run.click()
+
+    let completion = CompletionSheet(app: a)
+    if !completion.marker.waitForExistence(timeout: 120) {
+      dumpElementTree(a, label: "custom-runbackup-no-completion")
+      XCTFail("ImageIntact > Run Backup did not reach a completion sheet")
+    }
+  }
+}

--- a/ImageIntactUITests/MenuCommandUITests.swift
+++ b/ImageIntactUITests/MenuCommandUITests.swift
@@ -111,14 +111,18 @@ final class MenuCommandUITests: ImageIntactUITestCase {
 
   func testAppMenu_Preferences_OpensPreferences() throws {
     let a = launchApp(fixtures: nil)
-    guard open(a, appMenu(a), "app") else {
-      return XCTFail("application menu not found")
-    }
-    let prefs = a.menuItems.matching(
+    // The app hardcodes Button("Preferences..."); match "Settings" too in case it
+    // ever adopts a Settings scene (auto-renamed on macOS 13+). Scope to the app
+    // menu so the lookup can't resolve a degenerate-frame item in another menu.
+    let prefsTitle = appMenu(a).menuItems.matching(
       NSPredicate(format: "title BEGINSWITH %@ OR title BEGINSWITH %@", "Preferences", "Settings")
     ).firstMatch
-    XCTAssertTrue(prefs.waitForExistence(timeout: 5), "Preferences item missing from the app menu")
-    prefs.click()
+    guard open(a, appMenu(a), "app") else { return XCTFail("application menu not found") }
+    guard prefsTitle.waitForExistence(timeout: 5), waitUntilHittable(prefsTitle) else {
+      dumpElementTree(a, label: "menu-item-not-hittable-prefs")
+      return XCTFail("Preferences item not clickable in the app menu")
+    }
+    prefsTitle.click()
 
     let close = a.sheets.buttons["Close"].firstMatch
     XCTAssertTrue(close.waitForExistence(timeout: 10), "Preferences sheet did not open")
@@ -134,10 +138,9 @@ final class MenuCommandUITests: ImageIntactUITestCase {
     XCTAssertFalse(
       a.windows.buttons["Destination 2"].exists, "should start with one destination row")
 
-    guard open(a, menu(a, "File"), "file") else { return XCTFail("File menu not found") }
-    let add = menu(a, "File").menuItems["Add Destination"]
-    XCTAssertTrue(add.waitForExistence(timeout: 5), "File > Add Destination missing")
-    add.click()
+    guard clickItem(a, in: menu(a, "File"), "Add Destination", label: "file-add") else {
+      return XCTFail("File > Add Destination not clickable")
+    }
 
     XCTAssertTrue(
       a.windows.buttons["Destination 2"].waitForExistence(timeout: 5),
@@ -151,10 +154,9 @@ final class MenuCommandUITests: ImageIntactUITestCase {
     let main = MainScreen(app: a)
     XCTAssertTrue(main.folderRow("source").waitForExistence(timeout: 10), "seam source missing")
 
-    guard open(a, menu(a, "File"), "file") else { return XCTFail("File menu not found") }
-    let run = menu(a, "File").menuItems["Run Backup"]
-    XCTAssertTrue(run.waitForExistence(timeout: 5), "File > Run Backup missing")
-    run.click()
+    guard clickItem(a, in: menu(a, "File"), "Run Backup", label: "file-run") else {
+      return XCTFail("File > Run Backup not clickable")
+    }
 
     let completion = CompletionSheet(app: a)
     if !completion.marker.waitForExistence(timeout: 120) {
@@ -169,10 +171,9 @@ final class MenuCommandUITests: ImageIntactUITestCase {
     let a = launchApp(fixtures: nil)
     XCTAssertTrue(MainScreen(app: a).runBackupButton.waitForExistence(timeout: 10))
 
-    guard open(a, menu(a, "File"), "file") else { return XCTFail("File menu not found") }
-    let select = menu(a, "File").menuItems["Select Source Folder"]
-    XCTAssertTrue(select.waitForExistence(timeout: 5), "File > Select Source Folder missing")
-    select.click()
+    guard clickItem(a, in: menu(a, "File"), "Select Source Folder", label: "file-src") else {
+      return XCTFail("File > Select Source Folder not clickable")
+    }
 
     // App-modal NSOpenPanel surfaces as a Dialog with the system id "open-panel"
     // (see OpenPanelBackupUITests). We only prove the command opens it, then
@@ -195,10 +196,9 @@ final class MenuCommandUITests: ImageIntactUITestCase {
     XCTAssertTrue(
       MainScreen(app: a).folderRow("dest1").waitForExistence(timeout: 10), "seam dest1 missing")
 
-    guard open(a, menu(a, "File"), "file") else { return XCTFail("File menu not found") }
-    let select = menu(a, "File").menuItems["Select First Destination"]
-    XCTAssertTrue(select.waitForExistence(timeout: 5), "File > Select First Destination missing")
-    select.click()
+    guard clickItem(a, in: menu(a, "File"), "Select First Destination", label: "file-dest") else {
+      return XCTFail("File > Select First Destination not clickable")
+    }
 
     let panel = a.dialogs["open-panel"]
     if !panel.waitForExistence(timeout: 15) {
@@ -217,10 +217,9 @@ final class MenuCommandUITests: ImageIntactUITestCase {
     XCTAssertTrue(main.folderRow("source").waitForExistence(timeout: 10), "seam source missing")
     XCTAssertTrue(main.folderRow("dest1").exists, "seam dest1 missing")
 
-    guard open(a, menu(a, "Edit"), "edit") else { return XCTFail("Edit menu not found") }
-    let clear = menu(a, "Edit").menuItems["Clear All Selections"]
-    XCTAssertTrue(clear.waitForExistence(timeout: 5), "Edit > Clear All Selections missing")
-    clear.click()
+    guard clickItem(a, in: menu(a, "Edit"), "Clear All Selections", label: "edit-clear") else {
+      return XCTFail("Edit > Clear All Selections not clickable")
+    }
 
     XCTAssertTrue(
       main.folderRow("source").waitForNonExistence(timeout: 10),


### PR DESCRIPTION
## What

UI tests for the menu-bar command surface (AMUX-462, gh#139). No menu item was
driven by any UI test before this; the entire `Commands` surface had no
regression guard. `MenuCommandUITests` enumerates the real menu tree (from
`ImageIntactApp.swift .commands`, not guessed) and asserts each actionable
command triggers its effect via `app.menuBars` / `menuItems`.

Test-only — **no production code changes** (every asserted effect was already
observable through existing seams).

## Covered (command -> asserted effect)

| Menu | Command | Asserted effect |
|------|---------|-----------------|
| App | About ImageIntact | standard About dialog with "Version x" appears |
| App | Preferences… | Preferences sheet opens |
| File | Add Destination | a new empty "Destination 2" row appears |
| File | Run Backup | completion sheet (seam source + dest) |
| File | Select Source Folder | NSOpenPanel opens, cancelled |
| File | Select First Destination | NSOpenPanel opens, cancelled |
| Edit | Clear All Selections | seam source + dest rows clear |
| Help | ImageIntact Help | help window opens (its "Search Help" field) |
| ImageIntact (custom) | Run Backup | completion sheet (proves the custom menu is wired) |

That spans every custom menu group: the app menu, File, Edit, Help, and the
custom `CommandMenu("ImageIntact")`.

## Gotchas handled

- **Two menu-bar items titled "ImageIntact"** — the bold app menu and
  `CommandMenu("ImageIntact")`. The app menu is `menuBarItems.element(boundBy:
  1)`; the custom menu is disambiguated by a descendant-scoped probe for its
  custom-only "Verify Core Data Storage" item (an app-wide query matches both).
- **Duplicate commands across menus** (Run Backup / Add Destination / Clear All
  / Select Source/Dest live in two menus each) — every item click is scoped to
  its parent menu-bar item, as in AMUX-374's File-vs-ImageIntact "Add
  Destination".
- **Menu items report a degenerate frame until their menu is rendered** —
  clicking early throws an INFINITY-point exception, so `clickItem` waits until
  the item is genuinely hittable.
- **The Help window's displayed title is its default section** ("What's New –
  Version x"), not `NSWindow.title` ("ImageIntact Help") — identified by its
  unique "Search Help" field instead.

## Excluded (with reason)

- **Export Debug Log…** — opens an `NSSavePanel` (powerbox) + optional anonymize
  alert; the save target is out of scope and adds no command-wiring signal the
  open-panel tests don't already give.
- **Show Debug Log** — writes a temp file and `NSWorkspace.shared.open(...)`,
  handing off to an external app; the effect leaves the process, nothing in-app
  to assert.
- **Verify Core Data Storage** — app-modal `NSAlert.runModal()`; the custom menu
  is already covered by its Run Backup item, so this is left out to avoid a
  brittle modal loop.
- **Standard system items** (Apple menu, default Edit/Window items) —
  system-provided, not app commands.

Full covered/excluded rationale and runtime findings:
`.planning/design/ui-test-suite.md`.

## Incidental filed

- **AMUX-486** — Cmd-R / Cmd-K / Cmd-1 / Cmd-2 / Cmd-+ are each double-bound
  across File/Edit and the custom ImageIntact menu (redundant shortcuts),
  surfaced while enumerating the tree.

## Testing

Full unit + UI gate green via `imageintact-ui-gate.sh
feat/ui-tests-menu-commands` (no raw `xcodebuild` for UI tests), confirmed
across two consecutive runs. Red->green: tests committed red first (About / Help
/ custom-menu failing on un-tuned queries), then driven green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
