### PR TITLE
Fix post-cancel rerun zeroing global backup stats (AMUX-488)

### DIFF
--- a/ImageIntact/Models/BackupManager.swift
+++ b/ImageIntact/Models/BackupManager.swift
@@ -391,7 +391,23 @@ class BackupManager {
     }
 
     /// Force memory cleanup after backup completion or cancellation.
-    func cleanupMemory() {
+    ///
+    /// - Parameter expectedSessionID: when non-nil, the session this cleanup was
+    ///   scheduled for. If a newer backup has since replaced `state.sessionID`, the
+    ///   call bails entirely — a prior backup's deferred cleanup must not wipe the
+    ///   live run's progressTracker/statistics mid-copy (AMUX-488). `nil` (the
+    ///   synchronous `cancelOperation` caller) always runs.
+    func cleanupMemory(expectedSessionID: String? = nil) {
+        // AMUX-488: re-check the pinned session HERE, at execution time, because the
+        // QueueIntegration defer delays this call ~3s — long enough for a rerun to
+        // start and install its own session. If this cleanup belongs to a superseded
+        // backup, bail before touching any shared state (including the deferred
+        // resetAll that would zero the live run's global completion counters).
+        if let expectedSessionID, state.sessionID != expectedSessionID {
+            logInfo("cleanupMemory skipped: session changed (\(expectedSessionID) no longer current)", category: .performance)
+            return
+        }
+
         // Immediate cleanup — clear large data structures.
         state.logEntries.removeAll(keepingCapacity: false)
         state.debugLog.removeAll(keepingCapacity: false)

--- a/ImageIntact/Models/BackupManagerQueueIntegration.swift
+++ b/ImageIntact/Models/BackupManagerQueueIntegration.swift
@@ -37,6 +37,11 @@ extension BackupManager {
 
         // Reset state
         resetBackupState()
+        // AMUX-488: pin THIS backup's session (resetBackupState just assigned it) so the
+        // deferred cleanup below cannot wipe a later rerun's live state. Captured at the
+        // top — NOT inside the defer — to avoid a MainActor interleaving race where a
+        // rerun's resetBackupState runs before this backup's defer executes.
+        let backupSessionID = state.sessionID
 
         // Build manifest once for all preflight checks
         // This is more efficient than building it multiple times
@@ -203,7 +208,7 @@ extension BackupManager {
             // Schedule cleanup after a delay so UI can read the stats first
             Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds - give UI time to show stats
-                self?.cleanupMemory()
+                self?.cleanupMemory(expectedSessionID: backupSessionID)
                 ApplicationLogger.shared.debug("Memory cleanup completed after UI update", category: .backup)
             }
         }

--- a/ImageIntactTests/BackupStatisticsRerunTests.swift
+++ b/ImageIntactTests/BackupStatisticsRerunTests.swift
@@ -1,0 +1,128 @@
+//
+//  BackupStatisticsRerunTests.swift
+//  ImageIntactTests
+//
+//  TDD red-phase tests for AMUX-488: post-cancel rerun zeroing global completion stats.
+//
+//  References a NEW `cleanupMemory(expectedSessionID:)` parameter that does not exist
+//  yet. The compile failure here IS the red-phase signal (same precedent as
+//  BackupManagerCleanupTests.swift:9).
+//
+//  Root cause (see .planning/design/backup-manager-post-cancel-stats.md):
+//  a prior (cancelled) backup's 3s-deferred cleanupMemory() fires DURING the rerun,
+//  captures the rerun's sessionID, and ~10s later resetAll()s the LIVE progressTracker
+//  mid-copy. The monitor loop re-fills destinationProgress (per-dest stays correct) but
+//  totalFiles is set only once (BackupOrchestrator:288) and is not re-set, so
+//  processedFiles = min(maxCompleted, 0) = 0 and the completion sheet shows 0/0 inSource.
+//
+//  The fix lets the scheduling backup PIN its session; cleanupMemory bails when that
+//  pinned session is no longer current.
+//
+
+import XCTest
+@testable import ImageIntact
+
+@MainActor
+final class BackupStatisticsRerunTests: BaseBackupManagerTestCase {
+
+    // MARK: - Test fixtures
+
+    var mockFileOps: MockFileOperations!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockFileOps = MockFileOperations()
+        // self.bm is assigned per-test with its own deferredCleanupDelayNanos so the
+        // base tearDown can cancel any in-flight work.
+    }
+
+    override func tearDown() async throws {
+        mockFileOps = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Populate a tracker + statistics as a live, mid/just-completed rerun would:
+    /// global counters set, plus per-destination progress (which is correct in the bug).
+    private func populateLiveRunState(on bm: BackupManager, files: Int) {
+        bm.progressTracker.totalFiles = files
+        bm.progressTracker.processedFiles = files
+        bm.progressTracker.destinationProgress["dest1"] = files
+        bm.statistics.totalFilesInSource = files
+        bm.statistics.totalFilesProcessed = files
+    }
+
+    // MARK: - Tests
+
+    /// AMUX-488 core: a deferred cleanup scheduled by a PRIOR (cancelled) backup must not
+    /// wipe the live rerun's global counters, even though the cleanupMemory CALL happens
+    /// during the new session (the 3s defer delays it past the rerun's start). The prior
+    /// backup pins its own sessionID; cleanupMemory must bail when it no longer matches.
+    func testStaleDeferredCleanupFromPriorSession_doesNotZeroLiveGlobalCounters() async throws {
+        self.bm = BackupManager(
+            fileOperations: mockFileOps,
+            preferences: InMemoryPreferencesProvider(),
+            deferredCleanupDelayNanos: 50_000_000  // 50ms
+        )
+
+        // Live rerun session with populated counts, as orchestrator:288/539 + populateStatistics set them.
+        bm.state.sessionID = "rerun-session"
+        populateLiveRunState(on: bm, files: 6)
+
+        // The prior (cancelled) backup's deferred cleanup fires now, pinned to its OWN
+        // (old) session. New `expectedSessionID:` parameter — compile failure on current
+        // code is the red signal.
+        bm.cleanupMemory(expectedSessionID: "prior-cancelled-session")
+
+        // Wait well past the 50ms deferred delay so a non-bailing implementation would
+        // have wiped the tracker by now.
+        try await Task.sleep(for: .seconds(1))
+
+        // The live counters must survive — this is the AMUX-488 bug (they read 0/0).
+        XCTAssertEqual(bm.progressTracker.totalFiles, 6,
+                       "stale deferred cleanup wiped the live run's progressTracker.totalFiles")
+        XCTAssertEqual(bm.progressTracker.processedFiles, 6,
+                       "stale deferred cleanup wiped the live run's progressTracker.processedFiles")
+        XCTAssertEqual(bm.statistics.totalFilesInSource, 6,
+                       "stale deferred cleanup wiped the live run's statistics.totalFilesInSource")
+        XCTAssertEqual(bm.statistics.totalFilesProcessed, 6,
+                       "stale deferred cleanup wiped the live run's statistics.totalFilesProcessed")
+        // Per-destination aggregation is out of scope and should never have been touched.
+        XCTAssertEqual(bm.progressTracker.destinationProgress["dest1"], 6,
+                       "per-destination progress must be unaffected")
+    }
+
+    /// Regression: when the pinned session matches the live session, the deferred cleanup
+    /// STILL runs — the AMUX-488 guard must not neuter legitimate cleanup.
+    func testMatchingSessionDeferredCleanup_stillRuns() async throws {
+        self.bm = BackupManager(
+            fileOperations: mockFileOps,
+            preferences: InMemoryPreferencesProvider(),
+            deferredCleanupDelayNanos: 50_000_000  // 50ms
+        )
+
+        bm.state.sessionID = "live-session"
+        populateLiveRunState(on: bm, files: 6)
+        bm.state.failedFiles.append((
+            file: "/Volumes/Source/test.jpg",
+            destination: "/Volumes/BackupDrive",
+            error: "test error"
+        ))
+
+        // Cleanup pinned to the CURRENT session — should proceed and run the deferred task.
+        bm.cleanupMemory(expectedSessionID: "live-session")
+
+        // Poll up to 2s for the deferred task to clear failedFiles (proof it ran).
+        let deadline = Date().addingTimeInterval(2.0)
+        while !bm.state.failedFiles.isEmpty {
+            if Date() > deadline {
+                XCTFail("Deferred cleanup didn't run within 2s for a matching pinned session")
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertTrue(bm.state.failedFiles.isEmpty,
+                      "matching-session deferred cleanup must still clear failedFiles")
+    }
+}


### PR DESCRIPTION
## Problem
After cancelling a backup and running a fresh backup in the **same app session**, the completion sheet's global counters read `0` (`Files Processed: 0/0`; `processed=0`, `inSource=0`) even though the copy and verification succeed and the per-destination stats are correct (e.g. `dest1:c6/s0/f0`). A first, non-cancelled backup reports the counts correctly. Display-only (data is intact), but it reads as a failed backup.

Found during AMUX-370 (cancel-during-backup UI test). Repro: `src=6,dests=1` with a copy throttle; Run, cancel mid-copy, Run again; inspect `sheet.completion`.

## Root cause
The global counters (`BackupStatistics.totalFilesInSource` / `totalFilesProcessed`) are written in `populateStatistics` from `progressTracker.totalFiles` / `processedFiles`. The chain:

1. The cancelled backup's `performQueueBasedBackup` `defer` schedules `cleanupMemory()` after a 3s delay ("give UI time to show stats").
2. The user clicks Run again; the rerun starts a new session, builds a fresh `ProgressTracker`, begins copying.
3. The 3s-delayed `cleanupMemory()` fires **during the rerun** and captures `state.sessionID` at execution time — now the **rerun's** session — scheduling a deferred `resetAll()` guarded on it.
4. ~10s later the guard passes (session unchanged) and `resetAll()` wipes the **live** tracker mid-copy. The monitor loop re-fills `destinationProgress` (per-dest stays correct) but `totalFiles` is set only once (at orchestrator start) and is not re-set, so `processedFiles = min(maxCompleted, 0) = 0` and the sheet shows `0/0`.

The copy throttle in the repro is load-bearing: it widens the rerun's copy window so the wipe lands before `populateStatistics` reads the counters.

The existing sessionID guard protects the case where the session changes *after* `cleanupMemory` is called. It cannot protect a `cleanupMemory` *call* that is itself stale — delayed past the start of a new session by the 3s defer.

## Fix
Let the scheduling backup **pin the session it is cleaning up for**:
- `cleanupMemory(expectedSessionID:)` bails immediately when the pinned session is no longer current. `nil` (the synchronous `cancelOperation` caller) always runs.
- `performQueueBasedBackup` captures `let backupSessionID = state.sessionID` right after `resetBackupState()` and passes it into the deferred cleanup. Captured at the top, **not** inside the defer, to avoid a MainActor interleaving race where the rerun's `resetBackupState` runs before this backup's defer executes.

Per-destination aggregation is unchanged. No masking in `populateStatistics`.

## Testing
- New `ImageIntactTests/BackupStatisticsRerunTests.swift`:
  - a stale deferred cleanup from a prior session does not zero the live run's global counters (the bug);
  - a matching-session deferred cleanup still runs (the guard doesn't neuter cleanup).
- Existing `BackupManagerCleanupTests` (incl. the prior sessionID-guard test) still pass.
- Full unit + UI gate green.

**Scope note:** the unit test verifies the guard mechanism. The capture-location (top-of-function) correctness is reasoned, not tested. The green suite proves **no regression** — it does *not* reproduce the bug end-to-end: the red phase was a compile failure (not the 0/0 behavior), and the UI fixtures finish in ~2s while the wipe needs the deferred cleanup to land mid-copy ~13s in (3s defer + 10s delay), a window only the AMUX-461 throttle opens. The dedicated throttled cancel→rerun repro is deferred to **AMUX-492**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
